### PR TITLE
Disable default features for num

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Wrappers for total ordering on floats."
 repository = "https://github.com/reem/rust-ordered-float"
 
 [dependencies]
-num = "0.1"
+num = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 stainless = "*"


### PR DESCRIPTION
We only need the Float trait, so dropping default features cuts a lot
out of num we don't want, including the rustc_serialize dependency