### PR TITLE
Added `ops` for calculation to `NotNaN`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate unreachable;
 
 use std::cmp::Ordering;
 use std::error::Error;
-use std::ops::{Deref, DerefMut};
+use std::ops::{Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign};
 use std::hash::{Hash, Hasher};
 use std::fmt;
 use std::io;
@@ -221,6 +221,124 @@ impl<T: Float> Deref for NotNaN<T> {
 }
 
 impl<T: Float + PartialEq> Eq for NotNaN<T> {}
+
+impl<T: Float> Add for NotNaN<T> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        unsafe { NotNaN::unchecked_new(*self + *other) }
+    }
+}
+
+impl AddAssign for NotNaN<f64> {
+    fn add_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val += *other;
+    }
+}
+
+impl AddAssign for NotNaN<f32> {
+    fn add_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val += *other;
+    }
+}
+
+impl<T: Float> Sub for NotNaN<T> {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        unsafe { NotNaN::unchecked_new(*self - *other) }
+    }
+}
+
+impl SubAssign for NotNaN<f64> {
+    fn sub_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val -= *other;
+    }
+}
+
+impl SubAssign for NotNaN<f32> {
+    fn sub_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val -= *other;
+    }
+}
+
+impl<T: Float> Mul for NotNaN<T> {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        unsafe { NotNaN::unchecked_new(*self * *other) }
+    }
+}
+
+impl MulAssign for NotNaN<f64> {
+    fn mul_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val *= *other;
+    }
+}
+
+impl MulAssign for NotNaN<f32> {
+    fn mul_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val *= *other;
+    }
+}
+
+impl<T: Float> Div for NotNaN<T> {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        unsafe { NotNaN::unchecked_new(*self / *other) }
+    }
+}
+
+impl DivAssign for NotNaN<f64> {
+    fn div_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val /= *other;
+    }
+}
+
+impl DivAssign for NotNaN<f32> {
+    fn div_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val /= *other;
+    }
+}
+
+impl<T: Float> Rem for NotNaN<T> {
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self {
+        unsafe { NotNaN::unchecked_new(*self % *other) }
+    }
+}
+
+impl RemAssign for NotNaN<f64> {
+    fn rem_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val %= *other;
+    }
+}
+
+impl RemAssign for NotNaN<f32> {
+    fn rem_assign(&mut self, other: Self) {
+        let NotNaN(ref mut val) = *self;
+        *val %= *other;
+    }
+}
+
+impl<T: Float> Neg for NotNaN<T> {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        unsafe { NotNaN::unchecked_new(-*self) }
+    }
+}
 
 /// An error indicating an attempt to construct NotNaN from a NaN
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,21 +226,51 @@ impl<T: Float> Add for NotNaN<T> {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
-        unsafe { NotNaN::unchecked_new(*self + *other) }
+        NotNaN(self.0 + other.0)
+    }
+}
+
+/// Adds a float directly.
+///
+/// Panics if the provided value is NaN.
+impl<T: Float> Add<T> for NotNaN<T> {
+    type Output = Self;
+
+    fn add(self, other: T) -> Self {
+        assert!(!other.is_nan());
+        NotNaN(self.0 + other)
     }
 }
 
 impl AddAssign for NotNaN<f64> {
     fn add_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val += *other;
+        self.0 += other.0;
     }
 }
 
 impl AddAssign for NotNaN<f32> {
     fn add_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val += *other;
+        self.0 += other.0;
+    }
+}
+
+/// Adds a float directly.
+///
+/// Panics if the provided value is NaN.
+impl AddAssign<f64> for NotNaN<f64> {
+    fn add_assign(&mut self, other: f64) {
+        assert!(!other.is_nan());
+        self.0 += other;
+    }
+}
+
+/// Adds a float directly.
+///
+/// Panics if the provided value is NaN.
+impl AddAssign<f32> for NotNaN<f32> {
+    fn add_assign(&mut self, other: f32) {
+        assert!(!other.is_nan());
+        self.0 += other;
     }
 }
 
@@ -248,21 +278,51 @@ impl<T: Float> Sub for NotNaN<T> {
     type Output = Self;
 
     fn sub(self, other: Self) -> Self {
-        unsafe { NotNaN::unchecked_new(*self - *other) }
+        NotNaN(self.0 - other.0)
+    }
+}
+
+/// Subtracts a float directly.
+///
+/// Panics if the provided value is NaN.
+impl<T: Float> Sub<T> for NotNaN<T> {
+    type Output = Self;
+
+    fn sub(self, other: T) -> Self {
+        assert!(!other.is_nan());
+        NotNaN(self.0 - other)
     }
 }
 
 impl SubAssign for NotNaN<f64> {
     fn sub_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val -= *other;
+        self.0 -= other.0;
     }
 }
 
 impl SubAssign for NotNaN<f32> {
     fn sub_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val -= *other;
+        self.0 -= other.0;
+    }
+}
+
+/// Subtracts a float directly.
+///
+/// Panics if the provided value is NaN.
+impl SubAssign<f64> for NotNaN<f64> {
+    fn sub_assign(&mut self, other: f64) {
+        assert!(!other.is_nan());
+        self.0 -= other;
+    }
+}
+
+/// Subtracts a float directly.
+///
+/// Panics if the provided value is NaN.
+impl SubAssign<f32> for NotNaN<f32> {
+    fn sub_assign(&mut self, other: f32) {
+        assert!(!other.is_nan());
+        self.0 -= other;
     }
 }
 
@@ -270,21 +330,51 @@ impl<T: Float> Mul for NotNaN<T> {
     type Output = Self;
 
     fn mul(self, other: Self) -> Self {
-        unsafe { NotNaN::unchecked_new(*self * *other) }
+        NotNaN(self.0 * other.0)
+    }
+}
+
+/// Multiplies a float directly.
+///
+/// Panics if the provided value is NaN.
+impl<T: Float> Mul<T> for NotNaN<T> {
+    type Output = Self;
+
+    fn mul(self, other: T) -> Self {
+        assert!(!other.is_nan());
+        NotNaN(self.0 * other)
     }
 }
 
 impl MulAssign for NotNaN<f64> {
     fn mul_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val *= *other;
+        self.0 *= other.0;
     }
 }
 
 impl MulAssign for NotNaN<f32> {
     fn mul_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val *= *other;
+        self.0 *= other.0;
+    }
+}
+
+/// Multiplies a float directly.
+///
+/// Panics if the provided value is NaN.
+impl MulAssign<f64> for NotNaN<f64> {
+    fn mul_assign(&mut self, other: f64) {
+        assert!(!other.is_nan());
+        self.0 *= other;
+    }
+}
+
+/// Multiplies a float directly.
+///
+/// Panics if the provided value is NaN.
+impl MulAssign<f32> for NotNaN<f32> {
+    fn mul_assign(&mut self, other: f32) {
+        assert!(!other.is_nan());
+        self.0 *= other;
     }
 }
 
@@ -292,21 +382,51 @@ impl<T: Float> Div for NotNaN<T> {
     type Output = Self;
 
     fn div(self, other: Self) -> Self {
-        unsafe { NotNaN::unchecked_new(*self / *other) }
+        NotNaN(self.0 / other.0)
+    }
+}
+
+/// Divides a float directly.
+///
+/// Panics if the provided value is NaN.
+impl<T: Float> Div<T> for NotNaN<T> {
+    type Output = Self;
+
+    fn div(self, other: T) -> Self {
+        assert!(!other.is_nan());
+        NotNaN(self.0 / other)
     }
 }
 
 impl DivAssign for NotNaN<f64> {
     fn div_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val /= *other;
+        self.0 /= other.0;
     }
 }
 
 impl DivAssign for NotNaN<f32> {
     fn div_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val /= *other;
+        self.0 /= other.0;
+    }
+}
+
+/// Divides a float directly.
+///
+/// Panics if the provided value is NaN.
+impl DivAssign<f64> for NotNaN<f64> {
+    fn div_assign(&mut self, other: f64) {
+        assert!(!other.is_nan());
+        self.0 /= other;
+    }
+}
+
+/// Divides a float directly.
+///
+/// Panics if the provided value is NaN.
+impl DivAssign<f32> for NotNaN<f32> {
+    fn div_assign(&mut self, other: f32) {
+        assert!(!other.is_nan());
+        self.0 /= other;
     }
 }
 
@@ -314,21 +434,51 @@ impl<T: Float> Rem for NotNaN<T> {
     type Output = Self;
 
     fn rem(self, other: Self) -> Self {
-        unsafe { NotNaN::unchecked_new(*self % *other) }
+        NotNaN(self.0 % other.0)
+    }
+}
+
+/// Calculates `%` with a float directly.
+///
+/// Panics if the provided value is NaN.
+impl<T: Float> Rem<T> for NotNaN<T> {
+    type Output = Self;
+
+    fn rem(self, other: T) -> Self {
+        assert!(!other.is_nan());
+        NotNaN(self.0 % other)
     }
 }
 
 impl RemAssign for NotNaN<f64> {
     fn rem_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val %= *other;
+        self.0 %= other.0;
     }
 }
 
 impl RemAssign for NotNaN<f32> {
     fn rem_assign(&mut self, other: Self) {
-        let NotNaN(ref mut val) = *self;
-        *val %= *other;
+        self.0 %= other.0;
+    }
+}
+
+/// Calculates `%=` with a float directly.
+///
+/// Panics if the provided value is NaN.
+impl RemAssign<f64> for NotNaN<f64> {
+    fn rem_assign(&mut self, other: f64) {
+        assert!(!other.is_nan());
+        self.0 %= other;
+    }
+}
+
+/// Calculates `%=` with a float directly.
+///
+/// Panics if the provided value is NaN.
+impl RemAssign<f32> for NotNaN<f32> {
+    fn rem_assign(&mut self, other: f32) {
+        assert!(!other.is_nan());
+        self.0 %= other;
     }
 }
 
@@ -336,7 +486,7 @@ impl<T: Float> Neg for NotNaN<T> {
     type Output = Self;
 
     fn neg(self) -> Self {
-        unsafe { NotNaN::unchecked_new(-*self) }
+        NotNaN(-self.0)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,6 +7,7 @@ extern crate num;
 pub use ordered_float::*;
 pub use num::Float;
 pub use std::cmp::Ordering::*;
+pub use std::{f32, f64, panic};
 
 describe! ordered_float32 {
     it "should compare regular floats" {
@@ -52,11 +53,22 @@ describe! not_nan32 {
     
     it "should calculate correctly" {
         assert_eq!(*(NotNaN::from(5.0f32) + NotNaN::from(4.0f32)), 5.0f32 + 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) + 4.0f32), 5.0f32 + 4.0f32);
         assert_eq!(*(NotNaN::from(5.0f32) - NotNaN::from(4.0f32)), 5.0f32 - 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) - 4.0f32), 5.0f32 - 4.0f32);
         assert_eq!(*(NotNaN::from(5.0f32) * NotNaN::from(4.0f32)), 5.0f32 * 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) * 4.0f32), 5.0f32 * 4.0f32);
         assert_eq!(*(NotNaN::from(8.0f32) / NotNaN::from(4.0f32)), 8.0f32 / 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) / 4.0f32), 8.0f32 / 4.0f32);
         assert_eq!(*(NotNaN::from(8.0f32) % NotNaN::from(4.0f32)), 8.0f32 % 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) % 4.0f32), 8.0f32 % 4.0f32);
         assert_eq!(*(-NotNaN::from(1.0f32)), -1.0f32);
+        
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) + f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) - f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) * f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) / f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) % f32::NAN}).is_err());
         
         let mut number = NotNaN::from(5.0f32);
         number += NotNaN::from(4.0f32);
@@ -69,6 +81,24 @@ describe! not_nan32 {
         assert_eq!(*number, 5.0f32);
         number %= NotNaN::from(4.0f32);
         assert_eq!(*number, 1.0f32);
+        
+        number = NotNaN::from(5.0f32);
+        number += 4.0f32;
+        assert_eq!(*number, 9.0f32);
+        number -= 4.0f32;
+        assert_eq!(*number, 5.0f32);
+        number *= 4.0f32;
+        assert_eq!(*number, 20.0f32);
+        number /= 4.0f32;
+        assert_eq!(*number, 5.0f32);
+        number %= 4.0f32;
+        assert_eq!(*number, 1.0f32);
+        
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp += f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp -= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp *= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp /= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp %= f32::NAN;}).is_err());
     }
 }
 
@@ -86,11 +116,22 @@ describe! not_nan64 {
     
     it "should calculate correctly" {
         assert_eq!(*(NotNaN::from(5.0f64) + NotNaN::from(4.0f64)), 5.0f64 + 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) + 4.0f64), 5.0f64 + 4.0f64);
         assert_eq!(*(NotNaN::from(5.0f64) - NotNaN::from(4.0f64)), 5.0f64 - 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) - 4.0f64), 5.0f64 - 4.0f64);
         assert_eq!(*(NotNaN::from(5.0f64) * NotNaN::from(4.0f64)), 5.0f64 * 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) * 4.0f64), 5.0f64 * 4.0f64);
         assert_eq!(*(NotNaN::from(8.0f64) / NotNaN::from(4.0f64)), 8.0f64 / 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) / 4.0f64), 8.0f64 / 4.0f64);
         assert_eq!(*(NotNaN::from(8.0f64) % NotNaN::from(4.0f64)), 8.0f64 % 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) % 4.0f64), 8.0f64 % 4.0f64);
         assert_eq!(*(-NotNaN::from(1.0f64)), -1.0f64);
+        
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) + f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) - f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) * f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) / f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) % f64::NAN}).is_err());
         
         let mut number = NotNaN::from(5.0f64);
         number += NotNaN::from(4.0f64);
@@ -103,5 +144,23 @@ describe! not_nan64 {
         assert_eq!(*number, 5.0f64);
         number %= NotNaN::from(4.0f64);
         assert_eq!(*number, 1.0f64);
+        
+        number = NotNaN::from(5.0f64);
+        number += 4.0f64;
+        assert_eq!(*number, 9.0f64);
+        number -= 4.0f64;
+        assert_eq!(*number, 5.0f64);
+        number *= 4.0f64;
+        assert_eq!(*number, 20.0f64);
+        number /= 4.0f64;
+        assert_eq!(*number, 5.0f64);
+        number %= 4.0f64;
+        assert_eq!(*number, 1.0f64);
+        
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp += f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp -= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp *= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp /= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp %= f64::NAN;}).is_err());
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -49,6 +49,27 @@ describe! not_nan32 {
         let f32_nan: f32 = Float::nan();
         assert!(NotNaN::new(f32_nan).is_err());
     }
+    
+    it "should calculate correctly" {
+        assert_eq!(*(NotNaN::from(5.0f32) + NotNaN::from(4.0f32)), 5.0f32 + 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) - NotNaN::from(4.0f32)), 5.0f32 - 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) * NotNaN::from(4.0f32)), 5.0f32 * 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) / NotNaN::from(4.0f32)), 8.0f32 / 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) % NotNaN::from(4.0f32)), 8.0f32 % 4.0f32);
+        assert_eq!(*(-NotNaN::from(1.0f32)), -1.0f32);
+        
+        let mut number = NotNaN::from(5.0f32);
+        number += NotNaN::from(4.0f32);
+        assert_eq!(*number, 9.0f32);
+        number -= NotNaN::from(4.0f32);
+        assert_eq!(*number, 5.0f32);
+        number *= NotNaN::from(4.0f32);
+        assert_eq!(*number, 20.0f32);
+        number /= NotNaN::from(4.0f32);
+        assert_eq!(*number, 5.0f32);
+        number %= NotNaN::from(4.0f32);
+        assert_eq!(*number, 1.0f32);
+    }
 }
 
 describe! not_nan64 {
@@ -61,5 +82,26 @@ describe! not_nan64 {
     it "should fail when constructing NotNaN with NaN" {
         let f64_nan: f64 = Float::nan();
         assert!(NotNaN::new(f64_nan).is_err());
+    }
+    
+    it "should calculate correctly" {
+        assert_eq!(*(NotNaN::from(5.0f64) + NotNaN::from(4.0f64)), 5.0f64 + 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) - NotNaN::from(4.0f64)), 5.0f64 - 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) * NotNaN::from(4.0f64)), 5.0f64 * 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) / NotNaN::from(4.0f64)), 8.0f64 / 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) % NotNaN::from(4.0f64)), 8.0f64 % 4.0f64);
+        assert_eq!(*(-NotNaN::from(1.0f64)), -1.0f64);
+        
+        let mut number = NotNaN::from(5.0f64);
+        number += NotNaN::from(4.0f64);
+        assert_eq!(*number, 9.0f64);
+        number -= NotNaN::from(4.0f64);
+        assert_eq!(*number, 5.0f64);
+        number *= NotNaN::from(4.0f64);
+        assert_eq!(*number, 20.0f64);
+        number /= NotNaN::from(4.0f64);
+        assert_eq!(*number, 5.0f64);
+        number %= NotNaN::from(4.0f64);
+        assert_eq!(*number, 1.0f64);
     }
 }


### PR DESCRIPTION
I've added `ops` implementations for _addition_, _subtraction_, _multiplication_, _division_, _modulo_ and _negation_ to NotNaN.

This makes it easier to work with the types as it is often tedious to always `deref -> calc -> unsafe new` within your program.

I started the discussion for this in #11 some months ago and got at least one positive feedback.