### PR TITLE
Prefer `Nan` to `NaN`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,43 +141,43 @@ impl<T: Float + PartialEq> Eq for OrderedFloat<T> {}
 ///
 /// A NaN value cannot be stored in this type.
 #[derive(PartialOrd, PartialEq, Debug, Default, Clone, Copy)]
-pub struct NotNaN<T: Float>(T);
+pub struct NotNan<T: Float>(T);
 
-impl<T: Float> NotNaN<T> {
-    /// Create a NotNaN value.
+impl<T: Float> NotNan<T> {
+    /// Create a NotNan value.
     ///
     /// Returns Err if val is NaN
-    pub fn new(val: T) -> Result<Self, FloatIsNaN> {
+    pub fn new(val: T) -> Result<Self, FloatIsNan> {
         match val {
-            ref val if val.is_nan() => Err(FloatIsNaN),
-            val => Ok(NotNaN(val)),
+            ref val if val.is_nan() => Err(FloatIsNan),
+            val => Ok(NotNan(val)),
         }
     }
 
-    /// Create a NotNaN value from a value that is guaranteed to not be NaN
+    /// Create a NotNan value from a value that is guaranteed to not be NaN
     ///
     /// Behaviour is undefined if `val` is NaN
     pub unsafe fn unchecked_new(val: T) -> Self {
         debug_assert!(!val.is_nan());
-        NotNaN(val)
+        NotNan(val)
     }
 
     /// Get the value out.
     pub fn into_inner(self) -> T {
-        let NotNaN(val) = self;
+        let NotNan(val) = self;
         val
     }
 }
 
-impl<T: Float> AsRef<T> for NotNaN<T> {
+impl<T: Float> AsRef<T> for NotNan<T> {
     fn as_ref(&self) -> &T {
-        let NotNaN(ref val) = *self;
+        let NotNan(ref val) = *self;
         val
     }
 }
 
-impl<T: Float + PartialOrd> Ord for NotNaN<T> {
-    fn cmp(&self, other: &NotNaN<T>) -> Ordering {
+impl<T: Float + PartialOrd> Ord for NotNan<T> {
+    fn cmp(&self, other: &NotNan<T>) -> Ordering {
         match self.partial_cmp(&other) {
             Some(ord) => ord,
             None => unsafe { unreachable() },
@@ -185,41 +185,41 @@ impl<T: Float + PartialOrd> Ord for NotNaN<T> {
     }
 }
 
-impl<T: Float> Hash for NotNaN<T> {
+impl<T: Float> Hash for NotNan<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         hash_float(self.as_ref(), state)
     }
 }
 
-impl<T: Float + fmt::Display> fmt::Display for NotNaN<T> {
+impl<T: Float + fmt::Display> fmt::Display for NotNan<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_ref().fmt(f)
     }
 }
 
-impl Into<f32> for NotNaN<f32> {
+impl Into<f32> for NotNan<f32> {
     fn into(self) -> f32 {
         self.into_inner()
     }
 }
 
-impl Into<f64> for NotNaN<f64> {
+impl Into<f64> for NotNan<f64> {
     fn into(self) -> f64 {
         self.into_inner()
     }
 }
 
-/// Creates a NotNaN value from a Float.
+/// Creates a NotNan value from a Float.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: Float> From<T> for NotNaN<T> {
+impl<T: Float> From<T> for NotNan<T> {
     fn from(v: T) -> Self {
         assert!(!v.is_nan());
-        NotNaN(v)
+        NotNan(v)
     }
 }
 
-impl<T: Float> Deref for NotNaN<T> {
+impl<T: Float> Deref for NotNan<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -227,36 +227,36 @@ impl<T: Float> Deref for NotNaN<T> {
     }
 }
 
-impl<T: Float + PartialEq> Eq for NotNaN<T> {}
+impl<T: Float + PartialEq> Eq for NotNan<T> {}
 
-impl<T: Float> Add for NotNaN<T> {
+impl<T: Float> Add for NotNan<T> {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
-        NotNaN(self.0 + other.0)
+        NotNan(self.0 + other.0)
     }
 }
 
 /// Adds a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: Float> Add<T> for NotNaN<T> {
+impl<T: Float> Add<T> for NotNan<T> {
     type Output = Self;
 
     fn add(self, other: T) -> Self {
         assert!(!other.is_nan());
-        NotNaN::new(self.0 + other).expect("Addition resulted in NaN")
+        NotNan::new(self.0 + other).expect("Addition resulted in NaN")
     }
 }
 
-impl AddAssign for NotNaN<f64> {
+impl AddAssign for NotNan<f64> {
     fn add_assign(&mut self, other: Self) {
         self.0 += other.0;
         assert!(!self.0.is_nan(), "Addition resulted in NaN")
     }
 }
 
-impl AddAssign for NotNaN<f32> {
+impl AddAssign for NotNan<f32> {
     fn add_assign(&mut self, other: Self) {
         self.0 += other.0;
         assert!(!self.0.is_nan(), "Addition resulted in NaN")
@@ -266,7 +266,7 @@ impl AddAssign for NotNaN<f32> {
 /// Adds a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl AddAssign<f64> for NotNaN<f64> {
+impl AddAssign<f64> for NotNan<f64> {
     fn add_assign(&mut self, other: f64) {
         assert!(!other.is_nan());
         self.0 += other;
@@ -277,7 +277,7 @@ impl AddAssign<f64> for NotNaN<f64> {
 /// Adds a float directly.
 ///
 /// Panics if the provided value is NaN.
-impl AddAssign<f32> for NotNaN<f32> {
+impl AddAssign<f32> for NotNan<f32> {
     fn add_assign(&mut self, other: f32) {
         assert!(!other.is_nan());
         self.0 += other;
@@ -285,34 +285,34 @@ impl AddAssign<f32> for NotNaN<f32> {
     }
 }
 
-impl<T: Float> Sub for NotNaN<T> {
+impl<T: Float> Sub for NotNan<T> {
     type Output = Self;
 
     fn sub(self, other: Self) -> Self {
-        NotNaN::new(self.0 - other.0).expect("Subtraction resulted in NaN")
+        NotNan::new(self.0 - other.0).expect("Subtraction resulted in NaN")
     }
 }
 
 /// Subtracts a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: Float> Sub<T> for NotNaN<T> {
+impl<T: Float> Sub<T> for NotNan<T> {
     type Output = Self;
 
     fn sub(self, other: T) -> Self {
         assert!(!other.is_nan());
-        NotNaN::new(self.0 - other).expect("Subtraction resulted in NaN")
+        NotNan::new(self.0 - other).expect("Subtraction resulted in NaN")
     }
 }
 
-impl SubAssign for NotNaN<f64> {
+impl SubAssign for NotNan<f64> {
     fn sub_assign(&mut self, other: Self) {
         self.0 -= other.0;
         assert!(!self.0.is_nan(), "Subtraction resulted in NaN")
     }
 }
 
-impl SubAssign for NotNaN<f32> {
+impl SubAssign for NotNan<f32> {
     fn sub_assign(&mut self, other: Self) {
         self.0 -= other.0;
         assert!(!self.0.is_nan(), "Subtraction resulted in NaN")
@@ -322,7 +322,7 @@ impl SubAssign for NotNaN<f32> {
 /// Subtracts a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl SubAssign<f64> for NotNaN<f64> {
+impl SubAssign<f64> for NotNan<f64> {
     fn sub_assign(&mut self, other: f64) {
         assert!(!other.is_nan());
         self.0 -= other;
@@ -333,7 +333,7 @@ impl SubAssign<f64> for NotNaN<f64> {
 /// Subtracts a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl SubAssign<f32> for NotNaN<f32> {
+impl SubAssign<f32> for NotNan<f32> {
     fn sub_assign(&mut self, other: f32) {
         assert!(!other.is_nan());
         self.0 -= other;
@@ -341,34 +341,34 @@ impl SubAssign<f32> for NotNaN<f32> {
     }
 }
 
-impl<T: Float> Mul for NotNaN<T> {
+impl<T: Float> Mul for NotNan<T> {
     type Output = Self;
 
     fn mul(self, other: Self) -> Self {
-        NotNaN::new(self.0 * other.0).expect("Multiplication resulted in NaN")
+        NotNan::new(self.0 * other.0).expect("Multiplication resulted in NaN")
     }
 }
 
 /// Multiplies a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: Float> Mul<T> for NotNaN<T> {
+impl<T: Float> Mul<T> for NotNan<T> {
     type Output = Self;
 
     fn mul(self, other: T) -> Self {
         assert!(!other.is_nan());
-        NotNaN::new(self.0 * other).expect("Multiplication resulted in NaN")
+        NotNan::new(self.0 * other).expect("Multiplication resulted in NaN")
     }
 }
 
-impl MulAssign for NotNaN<f64> {
+impl MulAssign for NotNan<f64> {
     fn mul_assign(&mut self, other: Self) {
         self.0 *= other.0;
         assert!(!self.0.is_nan(), "Multiplication resulted in NaN")
     }
 }
 
-impl MulAssign for NotNaN<f32> {
+impl MulAssign for NotNan<f32> {
     fn mul_assign(&mut self, other: Self) {
         self.0 *= other.0;
         assert!(!self.0.is_nan(), "Multiplication resulted in NaN")
@@ -378,7 +378,7 @@ impl MulAssign for NotNaN<f32> {
 /// Multiplies a float directly.
 ///
 /// Panics if the provided value is NaN.
-impl MulAssign<f64> for NotNaN<f64> {
+impl MulAssign<f64> for NotNan<f64> {
     fn mul_assign(&mut self, other: f64) {
         assert!(!other.is_nan());
         self.0 *= other;
@@ -388,7 +388,7 @@ impl MulAssign<f64> for NotNaN<f64> {
 /// Multiplies a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl MulAssign<f32> for NotNaN<f32> {
+impl MulAssign<f32> for NotNan<f32> {
     fn mul_assign(&mut self, other: f32) {
         assert!(!other.is_nan());
         self.0 *= other;
@@ -396,34 +396,34 @@ impl MulAssign<f32> for NotNaN<f32> {
     }
 }
 
-impl<T: Float> Div for NotNaN<T> {
+impl<T: Float> Div for NotNan<T> {
     type Output = Self;
 
     fn div(self, other: Self) -> Self {
-        NotNaN::new(self.0 / other.0).expect("Division resulted in NaN")
+        NotNan::new(self.0 / other.0).expect("Division resulted in NaN")
     }
 }
 
 /// Divides a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: Float> Div<T> for NotNaN<T> {
+impl<T: Float> Div<T> for NotNan<T> {
     type Output = Self;
 
     fn div(self, other: T) -> Self {
         assert!(!other.is_nan());
-        NotNaN::new(self.0 / other).expect("Division resulted in NaN")
+        NotNan::new(self.0 / other).expect("Division resulted in NaN")
     }
 }
 
-impl DivAssign for NotNaN<f64> {
+impl DivAssign for NotNan<f64> {
     fn div_assign(&mut self, other: Self) {
         self.0 /= other.0;
         assert!(!self.0.is_nan(), "Division resulted in NaN")
     }
 }
 
-impl DivAssign for NotNaN<f32> {
+impl DivAssign for NotNan<f32> {
     fn div_assign(&mut self, other: Self) {
         self.0 /= other.0;
         assert!(!self.0.is_nan(), "Division resulted in NaN")
@@ -433,7 +433,7 @@ impl DivAssign for NotNaN<f32> {
 /// Divides a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl DivAssign<f64> for NotNaN<f64> {
+impl DivAssign<f64> for NotNan<f64> {
     fn div_assign(&mut self, other: f64) {
         assert!(!other.is_nan());
         self.0 /= other;
@@ -444,7 +444,7 @@ impl DivAssign<f64> for NotNaN<f64> {
 /// Divides a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl DivAssign<f32> for NotNaN<f32> {
+impl DivAssign<f32> for NotNan<f32> {
     fn div_assign(&mut self, other: f32) {
         assert!(!other.is_nan());
         self.0 /= other;
@@ -452,34 +452,34 @@ impl DivAssign<f32> for NotNaN<f32> {
     }
 }
 
-impl<T: Float> Rem for NotNaN<T> {
+impl<T: Float> Rem for NotNan<T> {
     type Output = Self;
 
     fn rem(self, other: Self) -> Self {
-        NotNaN::new(self.0 % other.0).expect("Rem resulted in NaN")
+        NotNan::new(self.0 % other.0).expect("Rem resulted in NaN")
     }
 }
 
 /// Calculates `%` with a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: Float> Rem<T> for NotNaN<T> {
+impl<T: Float> Rem<T> for NotNan<T> {
     type Output = Self;
 
     fn rem(self, other: T) -> Self {
         assert!(!other.is_nan());
-        NotNaN::new(self.0 % other).expect("Rem resulted in NaN")
+        NotNan::new(self.0 % other).expect("Rem resulted in NaN")
     }
 }
 
-impl RemAssign for NotNaN<f64> {
+impl RemAssign for NotNan<f64> {
     fn rem_assign(&mut self, other: Self) {
         self.0 %= other.0;
         assert!(!self.0.is_nan(), "Rem resulted in NaN")
     }
 }
 
-impl RemAssign for NotNaN<f32> {
+impl RemAssign for NotNan<f32> {
     fn rem_assign(&mut self, other: Self) {
         self.0 %= other.0;
         assert!(!self.0.is_nan(), "Rem resulted in NaN")
@@ -489,7 +489,7 @@ impl RemAssign for NotNaN<f32> {
 /// Calculates `%=` with a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl RemAssign<f64> for NotNaN<f64> {
+impl RemAssign<f64> for NotNan<f64> {
     fn rem_assign(&mut self, other: f64) {
         assert!(!other.is_nan());
         self.0 %= other;
@@ -500,7 +500,7 @@ impl RemAssign<f64> for NotNaN<f64> {
 /// Calculates `%=` with a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl RemAssign<f32> for NotNaN<f32> {
+impl RemAssign<f32> for NotNan<f32> {
     fn rem_assign(&mut self, other: f32) {
         assert!(!other.is_nan());
         self.0 %= other;
@@ -508,31 +508,31 @@ impl RemAssign<f32> for NotNaN<f32> {
     }
 }
 
-impl<T: Float> Neg for NotNaN<T> {
+impl<T: Float> Neg for NotNan<T> {
     type Output = Self;
 
     fn neg(self) -> Self {
-        NotNaN::new(-self.0).expect("Negation resulted in NaN")
+        NotNan::new(-self.0).expect("Negation resulted in NaN")
     }
 }
 
-/// An error indicating an attempt to construct NotNaN from a NaN
+/// An error indicating an attempt to construct NotNan from a NaN
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct FloatIsNaN;
+pub struct FloatIsNan;
 
-impl Error for FloatIsNaN {
+impl Error for FloatIsNan {
     fn description(&self) -> &str {
-        return "NotNaN constructed with NaN";
+        return "NotNan constructed with NaN";
     }
 }
 
-impl fmt::Display for FloatIsNaN {
+impl fmt::Display for FloatIsNan {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         <Self as fmt::Debug>::fmt(self, f)
     }
 }
 
-impl Into<io::Error> for FloatIsNaN {
+impl Into<io::Error> for FloatIsNan {
     fn into(self) -> io::Error {
         io::Error::new(io::ErrorKind::InvalidInput, self)
     }
@@ -564,7 +564,7 @@ mod impl_serde {
     extern crate serde;
     use self::serde::{Serialize, Serializer, Deserialize, Deserializer};
     use self::serde::de::{Error, Unexpected};
-    use super::{OrderedFloat, NotNaN};
+    use super::{OrderedFloat, NotNan};
     use num_traits::Float;
     use std::f64;
 
@@ -585,16 +585,16 @@ mod impl_serde {
         }
     }
 
-    impl<T: Float + Serialize> Serialize for NotNaN<T> {
+    impl<T: Float + Serialize> Serialize for NotNan<T> {
         fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
             self.0.serialize(s)
         }
     }
 
-    impl<'de, T: Float + Deserialize<'de>> Deserialize<'de> for NotNaN<T> {
+    impl<'de, T: Float + Deserialize<'de>> Deserialize<'de> for NotNan<T> {
         fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
             let float = T::deserialize(d)?;
-            NotNaN::new(float).map_err(|_| {
+            NotNan::new(float).map_err(|_| {
                 Error::invalid_value(Unexpected::Float(f64::NAN), &"float (but not NaN)")
             })
         }
@@ -608,13 +608,13 @@ mod impl_serde {
 
     #[test]
     fn test_not_nan() {
-        let float = NotNaN(1.0f64);
+        let float = NotNan(1.0f64);
         assert_tokens(&float, &[Token::F64(1.0)]);
     }
 
     #[test]
     fn test_fail_on_nan() {
-        assert_de_tokens_error::<NotNaN<f64>>(
+        assert_de_tokens_error::<NotNan<f64>>(
             &[Token::F64(f64::NAN)],
             "invalid value: floating point `NaN`, expected float (but not NaN)");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,16 @@ use std::mem;
 use unreachable::unreachable;
 use num_traits::Float;
 
+/// A wrapper around Floats providing an implementation of Ord and Hash.
+///
+/// A NaN value cannot be stored in this type.
+#[deprecated(since = "0.6.0", note = "renamed to `NotNan`")]
+pub type NotNaN<T> = NotNan<T>;
+
+/// An error indicating an attempt to construct NotNan from a NaN
+#[deprecated(since = "0.6.0", note = "renamed to `FloatIsNan`")]
+pub type FloatIsNaN = FloatIsNan;
+
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
 const EXP_MASK: u64 = 0x7ff0000000000000u64;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -45,48 +45,48 @@ describe! ordered_float64 {
 
 describe! not_nan32 {
     it "should compare regular floats" {
-        assert_eq!(NotNaN::from(7.0f32).cmp(&NotNaN::from(7.0)), Equal);
-        assert_eq!(NotNaN::from(8.0f32).cmp(&NotNaN::from(7.0)), Greater);
-        assert_eq!(NotNaN::from(4.0f32).cmp(&NotNaN::from(7.0)), Less);
+        assert_eq!(NotNan::from(7.0f32).cmp(&NotNan::from(7.0)), Equal);
+        assert_eq!(NotNan::from(8.0f32).cmp(&NotNan::from(7.0)), Greater);
+        assert_eq!(NotNan::from(4.0f32).cmp(&NotNan::from(7.0)), Less);
     }
 
-    it "should fail when constructing NotNaN with NaN" {
+    it "should fail when constructing NotNan with NaN" {
         let f32_nan: f32 = Float::nan();
-        assert!(NotNaN::new(f32_nan).is_err());
+        assert!(NotNan::new(f32_nan).is_err());
     }
     
     it "should calculate correctly" {
-        assert_eq!(*(NotNaN::from(5.0f32) + NotNaN::from(4.0f32)), 5.0f32 + 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) + 4.0f32), 5.0f32 + 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) - NotNaN::from(4.0f32)), 5.0f32 - 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) - 4.0f32), 5.0f32 - 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) * NotNaN::from(4.0f32)), 5.0f32 * 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) * 4.0f32), 5.0f32 * 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) / NotNaN::from(4.0f32)), 8.0f32 / 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) / 4.0f32), 8.0f32 / 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) % NotNaN::from(4.0f32)), 8.0f32 % 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) % 4.0f32), 8.0f32 % 4.0f32);
-        assert_eq!(*(-NotNaN::from(1.0f32)), -1.0f32);
+        assert_eq!(*(NotNan::from(5.0f32) + NotNan::from(4.0f32)), 5.0f32 + 4.0f32);
+        assert_eq!(*(NotNan::from(5.0f32) + 4.0f32), 5.0f32 + 4.0f32);
+        assert_eq!(*(NotNan::from(5.0f32) - NotNan::from(4.0f32)), 5.0f32 - 4.0f32);
+        assert_eq!(*(NotNan::from(5.0f32) - 4.0f32), 5.0f32 - 4.0f32);
+        assert_eq!(*(NotNan::from(5.0f32) * NotNan::from(4.0f32)), 5.0f32 * 4.0f32);
+        assert_eq!(*(NotNan::from(5.0f32) * 4.0f32), 5.0f32 * 4.0f32);
+        assert_eq!(*(NotNan::from(8.0f32) / NotNan::from(4.0f32)), 8.0f32 / 4.0f32);
+        assert_eq!(*(NotNan::from(8.0f32) / 4.0f32), 8.0f32 / 4.0f32);
+        assert_eq!(*(NotNan::from(8.0f32) % NotNan::from(4.0f32)), 8.0f32 % 4.0f32);
+        assert_eq!(*(NotNan::from(8.0f32) % 4.0f32), 8.0f32 % 4.0f32);
+        assert_eq!(*(-NotNan::from(1.0f32)), -1.0f32);
         
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) + f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) - f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) * f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) / f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) % f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f32) + f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f32) - f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f32) * f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f32) / f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f32) % f32::NAN}).is_err());
         
-        let mut number = NotNaN::from(5.0f32);
-        number += NotNaN::from(4.0f32);
+        let mut number = NotNan::from(5.0f32);
+        number += NotNan::from(4.0f32);
         assert_eq!(*number, 9.0f32);
-        number -= NotNaN::from(4.0f32);
+        number -= NotNan::from(4.0f32);
         assert_eq!(*number, 5.0f32);
-        number *= NotNaN::from(4.0f32);
+        number *= NotNan::from(4.0f32);
         assert_eq!(*number, 20.0f32);
-        number /= NotNaN::from(4.0f32);
+        number /= NotNan::from(4.0f32);
         assert_eq!(*number, 5.0f32);
-        number %= NotNaN::from(4.0f32);
+        number %= NotNan::from(4.0f32);
         assert_eq!(*number, 1.0f32);
         
-        number = NotNaN::from(5.0f32);
+        number = NotNan::from(5.0f32);
         number += 4.0f32;
         assert_eq!(*number, 9.0f32);
         number -= 4.0f32;
@@ -98,58 +98,58 @@ describe! not_nan32 {
         number %= 4.0f32;
         assert_eq!(*number, 1.0f32);
         
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp += f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp -= f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp *= f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp /= f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp %= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f32); tmp += f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f32); tmp -= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f32); tmp *= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f32); tmp /= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f32); tmp %= f32::NAN;}).is_err());
     }
 }
 
 describe! not_nan64 {
     it "should compare regular floats" {
-        assert_eq!(NotNaN::from(7.0f64).cmp(&NotNaN::from(7.0)), Equal);
-        assert_eq!(NotNaN::from(8.0f64).cmp(&NotNaN::from(7.0)), Greater);
-        assert_eq!(NotNaN::from(4.0f64).cmp(&NotNaN::from(7.0)), Less);
+        assert_eq!(NotNan::from(7.0f64).cmp(&NotNan::from(7.0)), Equal);
+        assert_eq!(NotNan::from(8.0f64).cmp(&NotNan::from(7.0)), Greater);
+        assert_eq!(NotNan::from(4.0f64).cmp(&NotNan::from(7.0)), Less);
     }
 
-    it "should fail when constructing NotNaN with NaN" {
+    it "should fail when constructing NotNan with NaN" {
         let f64_nan: f64 = Float::nan();
-        assert!(NotNaN::new(f64_nan).is_err());
+        assert!(NotNan::new(f64_nan).is_err());
     }
     
     it "should calculate correctly" {
-        assert_eq!(*(NotNaN::from(5.0f64) + NotNaN::from(4.0f64)), 5.0f64 + 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) + 4.0f64), 5.0f64 + 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) - NotNaN::from(4.0f64)), 5.0f64 - 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) - 4.0f64), 5.0f64 - 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) * NotNaN::from(4.0f64)), 5.0f64 * 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) * 4.0f64), 5.0f64 * 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) / NotNaN::from(4.0f64)), 8.0f64 / 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) / 4.0f64), 8.0f64 / 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) % NotNaN::from(4.0f64)), 8.0f64 % 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) % 4.0f64), 8.0f64 % 4.0f64);
-        assert_eq!(*(-NotNaN::from(1.0f64)), -1.0f64);
+        assert_eq!(*(NotNan::from(5.0f64) + NotNan::from(4.0f64)), 5.0f64 + 4.0f64);
+        assert_eq!(*(NotNan::from(5.0f64) + 4.0f64), 5.0f64 + 4.0f64);
+        assert_eq!(*(NotNan::from(5.0f64) - NotNan::from(4.0f64)), 5.0f64 - 4.0f64);
+        assert_eq!(*(NotNan::from(5.0f64) - 4.0f64), 5.0f64 - 4.0f64);
+        assert_eq!(*(NotNan::from(5.0f64) * NotNan::from(4.0f64)), 5.0f64 * 4.0f64);
+        assert_eq!(*(NotNan::from(5.0f64) * 4.0f64), 5.0f64 * 4.0f64);
+        assert_eq!(*(NotNan::from(8.0f64) / NotNan::from(4.0f64)), 8.0f64 / 4.0f64);
+        assert_eq!(*(NotNan::from(8.0f64) / 4.0f64), 8.0f64 / 4.0f64);
+        assert_eq!(*(NotNan::from(8.0f64) % NotNan::from(4.0f64)), 8.0f64 % 4.0f64);
+        assert_eq!(*(NotNan::from(8.0f64) % 4.0f64), 8.0f64 % 4.0f64);
+        assert_eq!(*(-NotNan::from(1.0f64)), -1.0f64);
         
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) + f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) - f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) * f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) / f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) % f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f64) + f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f64) - f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f64) * f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f64) / f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNan::from(0.0f64) % f64::NAN}).is_err());
         
-        let mut number = NotNaN::from(5.0f64);
-        number += NotNaN::from(4.0f64);
+        let mut number = NotNan::from(5.0f64);
+        number += NotNan::from(4.0f64);
         assert_eq!(*number, 9.0f64);
-        number -= NotNaN::from(4.0f64);
+        number -= NotNan::from(4.0f64);
         assert_eq!(*number, 5.0f64);
-        number *= NotNaN::from(4.0f64);
+        number *= NotNan::from(4.0f64);
         assert_eq!(*number, 20.0f64);
-        number /= NotNaN::from(4.0f64);
+        number /= NotNan::from(4.0f64);
         assert_eq!(*number, 5.0f64);
-        number %= NotNaN::from(4.0f64);
+        number %= NotNan::from(4.0f64);
         assert_eq!(*number, 1.0f64);
         
-        number = NotNaN::from(5.0f64);
+        number = NotNan::from(5.0f64);
         number += 4.0f64;
         assert_eq!(*number, 9.0f64);
         number -= 4.0f64;
@@ -161,11 +161,11 @@ describe! not_nan64 {
         number %= 4.0f64;
         assert_eq!(*number, 1.0f64);
         
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp += f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp -= f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp *= f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp /= f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp %= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f64); tmp += f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f64); tmp -= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f64); tmp *= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f64); tmp /= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNan::from(0.0f64); tmp %= f64::NAN;}).is_err());
     }
 }
 

--- a/tests/test_deprecated_names.rs
+++ b/tests/test_deprecated_names.rs
@@ -1,0 +1,227 @@
+#![feature(plugin)]
+#![plugin(stainless)]
+#![allow(deprecated)]
+
+extern crate ordered_float;
+extern crate num_traits;
+
+pub use ordered_float::*;
+pub use num_traits::Float;
+pub use std::cmp::Ordering::*;
+pub use std::{f32, f64, panic};
+
+pub use std::collections::HashSet;
+pub use std::collections::hash_map::RandomState;
+pub use std::hash::*;
+
+describe! ordered_float32 {
+    it "should compare regular floats" {
+        assert_eq!(OrderedFloat(7.0f32).cmp(&OrderedFloat(7.0)), Equal);
+        assert_eq!(OrderedFloat(8.0f32).cmp(&OrderedFloat(7.0)), Greater);
+        assert_eq!(OrderedFloat(4.0f32).cmp(&OrderedFloat(7.0)), Less);
+    }
+
+    it "should compare NaN" {
+        let f32_nan: f32 = Float::nan();
+        assert_eq!(OrderedFloat(f32_nan).cmp(&OrderedFloat(Float::nan())), Equal);
+        assert_eq!(OrderedFloat(f32_nan).cmp(&OrderedFloat(-100000.0f32)), Greater);
+        assert_eq!(OrderedFloat(-100.0f32).cmp(&OrderedFloat(Float::nan())), Less);
+    }
+}
+
+describe! ordered_float64 {
+    it "should compare regular floats" {
+        assert_eq!(OrderedFloat(7.0f64).cmp(&OrderedFloat(7.0)), Equal);
+        assert_eq!(OrderedFloat(8.0f64).cmp(&OrderedFloat(7.0)), Greater);
+        assert_eq!(OrderedFloat(4.0f64).cmp(&OrderedFloat(7.0)), Less);
+    }
+
+    it "should compare NaN" {
+        let f64_nan: f64 = Float::nan();
+        assert_eq!(OrderedFloat(f64_nan).cmp(&OrderedFloat(Float::nan())), Equal);
+        assert_eq!(OrderedFloat(f64_nan).cmp(&OrderedFloat(-100000.0f64)), Greater);
+        assert_eq!(OrderedFloat(-100.0f64).cmp(&OrderedFloat(Float::nan())), Less);
+    }
+}
+
+describe! not_nan32 {
+    it "should compare regular floats" {
+        assert_eq!(NotNaN::from(7.0f32).cmp(&NotNaN::from(7.0)), Equal);
+        assert_eq!(NotNaN::from(8.0f32).cmp(&NotNaN::from(7.0)), Greater);
+        assert_eq!(NotNaN::from(4.0f32).cmp(&NotNaN::from(7.0)), Less);
+    }
+
+    it "should fail when constructing NotNaN with NaN" {
+        let f32_nan: f32 = Float::nan();
+        assert!(NotNaN::new(f32_nan).is_err());
+    }
+    
+    it "should calculate correctly" {
+        assert_eq!(*(NotNaN::from(5.0f32) + NotNaN::from(4.0f32)), 5.0f32 + 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) + 4.0f32), 5.0f32 + 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) - NotNaN::from(4.0f32)), 5.0f32 - 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) - 4.0f32), 5.0f32 - 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) * NotNaN::from(4.0f32)), 5.0f32 * 4.0f32);
+        assert_eq!(*(NotNaN::from(5.0f32) * 4.0f32), 5.0f32 * 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) / NotNaN::from(4.0f32)), 8.0f32 / 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) / 4.0f32), 8.0f32 / 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) % NotNaN::from(4.0f32)), 8.0f32 % 4.0f32);
+        assert_eq!(*(NotNaN::from(8.0f32) % 4.0f32), 8.0f32 % 4.0f32);
+        assert_eq!(*(-NotNaN::from(1.0f32)), -1.0f32);
+        
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) + f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) - f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) * f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) / f32::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) % f32::NAN}).is_err());
+        
+        let mut number = NotNaN::from(5.0f32);
+        number += NotNaN::from(4.0f32);
+        assert_eq!(*number, 9.0f32);
+        number -= NotNaN::from(4.0f32);
+        assert_eq!(*number, 5.0f32);
+        number *= NotNaN::from(4.0f32);
+        assert_eq!(*number, 20.0f32);
+        number /= NotNaN::from(4.0f32);
+        assert_eq!(*number, 5.0f32);
+        number %= NotNaN::from(4.0f32);
+        assert_eq!(*number, 1.0f32);
+        
+        number = NotNaN::from(5.0f32);
+        number += 4.0f32;
+        assert_eq!(*number, 9.0f32);
+        number -= 4.0f32;
+        assert_eq!(*number, 5.0f32);
+        number *= 4.0f32;
+        assert_eq!(*number, 20.0f32);
+        number /= 4.0f32;
+        assert_eq!(*number, 5.0f32);
+        number %= 4.0f32;
+        assert_eq!(*number, 1.0f32);
+        
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp += f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp -= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp *= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp /= f32::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp %= f32::NAN;}).is_err());
+    }
+}
+
+describe! not_nan64 {
+    it "should compare regular floats" {
+        assert_eq!(NotNaN::from(7.0f64).cmp(&NotNaN::from(7.0)), Equal);
+        assert_eq!(NotNaN::from(8.0f64).cmp(&NotNaN::from(7.0)), Greater);
+        assert_eq!(NotNaN::from(4.0f64).cmp(&NotNaN::from(7.0)), Less);
+    }
+
+    it "should fail when constructing NotNaN with NaN" {
+        let f64_nan: f64 = Float::nan();
+        assert!(NotNaN::new(f64_nan).is_err());
+    }
+    
+    it "should calculate correctly" {
+        assert_eq!(*(NotNaN::from(5.0f64) + NotNaN::from(4.0f64)), 5.0f64 + 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) + 4.0f64), 5.0f64 + 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) - NotNaN::from(4.0f64)), 5.0f64 - 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) - 4.0f64), 5.0f64 - 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) * NotNaN::from(4.0f64)), 5.0f64 * 4.0f64);
+        assert_eq!(*(NotNaN::from(5.0f64) * 4.0f64), 5.0f64 * 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) / NotNaN::from(4.0f64)), 8.0f64 / 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) / 4.0f64), 8.0f64 / 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) % NotNaN::from(4.0f64)), 8.0f64 % 4.0f64);
+        assert_eq!(*(NotNaN::from(8.0f64) % 4.0f64), 8.0f64 % 4.0f64);
+        assert_eq!(*(-NotNaN::from(1.0f64)), -1.0f64);
+        
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) + f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) - f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) * f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) / f64::NAN}).is_err());
+        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) % f64::NAN}).is_err());
+        
+        let mut number = NotNaN::from(5.0f64);
+        number += NotNaN::from(4.0f64);
+        assert_eq!(*number, 9.0f64);
+        number -= NotNaN::from(4.0f64);
+        assert_eq!(*number, 5.0f64);
+        number *= NotNaN::from(4.0f64);
+        assert_eq!(*number, 20.0f64);
+        number /= NotNaN::from(4.0f64);
+        assert_eq!(*number, 5.0f64);
+        number %= NotNaN::from(4.0f64);
+        assert_eq!(*number, 1.0f64);
+        
+        number = NotNaN::from(5.0f64);
+        number += 4.0f64;
+        assert_eq!(*number, 9.0f64);
+        number -= 4.0f64;
+        assert_eq!(*number, 5.0f64);
+        number *= 4.0f64;
+        assert_eq!(*number, 20.0f64);
+        number /= 4.0f64;
+        assert_eq!(*number, 5.0f64);
+        number %= 4.0f64;
+        assert_eq!(*number, 1.0f64);
+        
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp += f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp -= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp *= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp /= f64::NAN;}).is_err());
+        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp %= f64::NAN;}).is_err());
+    }
+}
+
+describe! hashing {
+    it "should hash zero and neg-zero to the same hc" {
+        let state = RandomState::new();
+        let mut h1 = state.build_hasher();
+        let mut h2 = state.build_hasher();
+        OrderedFloat::from(0f64).hash(&mut h1);
+        OrderedFloat::from(-0f64).hash(&mut h2);
+        assert_eq!(h1.finish(), h2.finish());
+    }
+
+    it "should hash inf and neg-inf to different hcs" {
+        let state = RandomState::new();
+        let mut h1 = state.build_hasher();
+        let mut h2 = state.build_hasher();
+        OrderedFloat::from(f64::INFINITY).hash(&mut h1);
+        OrderedFloat::from(f64::NEG_INFINITY).hash(&mut h2);
+        assert!(h1.finish() != h2.finish());
+    }
+
+    it "should have a good hash function for whole numbers" {
+        let state = RandomState::new();
+        let limit = 10000;
+
+        let mut set = ::std::collections::HashSet::with_capacity(limit);
+        for i in 0..limit {
+            let mut h = state.build_hasher();
+            OrderedFloat::from(i as f64).hash(&mut h);
+            set.insert(h.finish());
+        }
+
+        // This allows 100 collisions, which is far too
+        // many, but should guard against transient issues
+        // that will result from using RandomState
+        let pct_unique = set.len() as f64 / limit as f64;
+        assert!(0.99f64 < pct_unique, "percent-unique={}", pct_unique);
+    }
+
+    it "should have a good hash function for fractional numbers" {
+        let state = RandomState::new();
+        let limit = 10000;
+
+        let mut set = ::std::collections::HashSet::with_capacity(limit);
+        for i in 0..limit {
+            let mut h = state.build_hasher();
+            OrderedFloat::from(i as f64 * (1f64 / limit as f64)).hash(&mut h);
+            set.insert(h.finish());
+        }
+
+        // This allows 100 collisions, which is far too
+        // many, but should guard against transient issues
+        // that will result from using RandomState
+        let pct_unique = set.len() as f64 / limit as f64;
+        assert!(0.99f64 < pct_unique, "percent-unique={}", pct_unique);
+    }
+}


### PR DESCRIPTION
[Rust's RFC 0430 about naming conventions](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md#fine-points) says:

> In `CamelCase`, acronyms count as one word: use `Uuid` rather than `UUID`.

Standard library follows this rule and uses `Nan` (see [`std::num::FpCategory::Nan`](https://doc.rust-lang.org/std/num/enum.FpCategory.html#variant.Nan)), so this crate had better use `Nan`.