### PR TITLE
Implement several traits from `num_traits` for `NotNaN`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use unreachable::unreachable;
-use num_traits::{Bounded, Float, One, Zero};
+use num_traits::{Bounded, Float, FromPrimitive, One, Zero};
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
@@ -577,6 +577,22 @@ impl<T: Float + Bounded> Bounded for NotNaN<T> {
     fn max_value() -> Self {
         NotNaN(Bounded::max_value())
     }
+}
+
+impl<T: Float + FromPrimitive> FromPrimitive for NotNaN<T> {
+    fn from_i64(n: i64) -> Option<Self> { T::from_i64(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_u64(n: u64) -> Option<Self> { T::from_u64(n).and_then(|n| NotNaN::new(n).ok()) }
+
+    fn from_isize(n: isize) -> Option<Self> { T::from_isize(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_i8(n: i8) -> Option<Self> { T::from_i8(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_i16(n: i16) -> Option<Self> { T::from_i16(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_i32(n: i32) -> Option<Self> { T::from_i32(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_usize(n: usize) -> Option<Self> { T::from_usize(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_u8(n: u8) -> Option<Self> { T::from_u8(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_u16(n: u16) -> Option<Self> { T::from_u16(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_u32(n: u32) -> Option<Self> { T::from_u32(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_f32(n: f32) -> Option<Self> { T::from_f32(n).and_then(|n| NotNaN::new(n).ok()) }
+    fn from_f64(n: f64) -> Option<Self> { T::from_f64(n).and_then(|n| NotNaN::new(n).ok()) }
 }
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use unreachable::unreachable;
-use num_traits::Float;
+use num_traits::{Bounded, Float};
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
@@ -557,6 +557,16 @@ fn raw_double_bits<F: Float>(f: &F) -> u64 {
     let exp_u64 = unsafe { mem::transmute::<i16, u16>(exp) } as u64;
     let sign_u64 = if sign > 0 { 1u64 } else { 0u64 };
     (man & MAN_MASK) | ((exp_u64 << 52) & EXP_MASK) | ((sign_u64 << 63) & SIGN_MASK)
+}
+
+impl<T: Float + Bounded> Bounded for NotNaN<T> {
+    fn min_value() -> Self {
+        NotNaN(Bounded::min_value())
+    }
+
+    fn max_value() -> Self {
+        NotNaN(Bounded::max_value())
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use unreachable::unreachable;
-use num_traits::{Bounded, Float};
+use num_traits::{Bounded, Float, One, Zero};
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
@@ -557,6 +557,16 @@ fn raw_double_bits<F: Float>(f: &F) -> u64 {
     let exp_u64 = unsafe { mem::transmute::<i16, u16>(exp) } as u64;
     let sign_u64 = if sign > 0 { 1u64 } else { 0u64 };
     (man & MAN_MASK) | ((exp_u64 << 52) & EXP_MASK) | ((sign_u64 << 63) & SIGN_MASK)
+}
+
+impl<T: Float + Zero> Zero for NotNaN<T> {
+    fn zero() -> Self { NotNaN(T::zero()) }
+
+    fn is_zero(&self) -> bool { self.0.is_zero() }
+}
+
+impl<T: Float + One> One for NotNaN<T> {
+    fn one() -> Self { NotNaN(T::one()) }
 }
 
 impl<T: Float + Bounded> Bounded for NotNaN<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use unreachable::unreachable;
-use num_traits::{Bounded, Float, FromPrimitive, Num, One, ToPrimitive, Zero};
+use num_traits::{Bounded, Float, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
@@ -640,6 +640,18 @@ impl<T: Float + Num> Num for NotNaN<T> {
             .map_err(|err| ParseNotNaNError::ParseFloatError(err))
             .and_then(|n| NotNaN::new(n).map_err(|_| ParseNotNaNError::IsNaN))
     }
+}
+
+impl<T: Float + Signed> Signed for NotNaN<T> {
+    fn abs(&self) -> Self { NotNaN(self.0.abs()) }
+
+    fn abs_sub(&self, other: &Self) -> Self {
+        NotNaN::new(self.0.abs_sub(other.0)).expect("Subtraction resulted in NaN")
+    }
+
+    fn signum(&self) -> Self { NotNaN(self.0.signum()) }
+    fn is_positive(&self) -> bool { self.0.is_positive() }
+    fn is_negative(&self) -> bool { self.0.is_negative() }
 }
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ use std::fmt;
 use std::io;
 use std::mem;
 use unreachable::unreachable;
-use num_traits::{Bounded, Float, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+use num_traits::{Bounded, Float, FromPrimitive, Num, NumCast, One, Signed, ToPrimitive,
+                 Zero};
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
@@ -652,6 +653,12 @@ impl<T: Float + Signed> Signed for NotNaN<T> {
     fn signum(&self) -> Self { NotNaN(self.0.signum()) }
     fn is_positive(&self) -> bool { self.0.is_positive() }
     fn is_negative(&self) -> bool { self.0.is_negative() }
+}
+
+impl<T: Float + NumCast> NumCast for NotNaN<T> {
+    fn from<F: ToPrimitive>(n: F) -> Option<Self> {
+        T::from(n).and_then(|n| NotNaN::new(n).ok())
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use unreachable::unreachable;
-use num_traits::{Bounded, Float, FromPrimitive, One, Zero};
+use num_traits::{Bounded, Float, FromPrimitive, One, ToPrimitive, Zero};
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
@@ -593,6 +593,22 @@ impl<T: Float + FromPrimitive> FromPrimitive for NotNaN<T> {
     fn from_u32(n: u32) -> Option<Self> { T::from_u32(n).and_then(|n| NotNaN::new(n).ok()) }
     fn from_f32(n: f32) -> Option<Self> { T::from_f32(n).and_then(|n| NotNaN::new(n).ok()) }
     fn from_f64(n: f64) -> Option<Self> { T::from_f64(n).and_then(|n| NotNaN::new(n).ok()) }
+}
+
+impl<T: Float + ToPrimitive> ToPrimitive for NotNaN<T> {
+    fn to_i64(&self) -> Option<i64> { self.0.to_i64() }
+    fn to_u64(&self) -> Option<u64> { self.0.to_u64() }
+
+    fn to_isize(&self) -> Option<isize> { self.0.to_isize() }
+    fn to_i8(&self) -> Option<i8> { self.0.to_i8() }
+    fn to_i16(&self) -> Option<i16> { self.0.to_i16() }
+    fn to_i32(&self) -> Option<i32> { self.0.to_i32() }
+    fn to_usize(&self) -> Option<usize> { self.0.to_usize() }
+    fn to_u8(&self) -> Option<u8> { self.0.to_u8() }
+    fn to_u16(&self) -> Option<u16> { self.0.to_u16() }
+    fn to_u32(&self) -> Option<u32> { self.0.to_u32() }
+    fn to_f32(&self) -> Option<f32> { self.0.to_f32() }
+    fn to_f64(&self) -> Option<f64> { self.0.to_f64() }
 }
 
 #[cfg(feature = "serde")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate ordered_float;
 extern crate num_traits;
 
 pub use ordered_float::*;
-pub use num_traits::{Bounded, Float, One, Zero};
+pub use num_traits::{Bounded, Float, FromPrimitive, One, Zero};
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 
@@ -118,6 +118,25 @@ describe! not_nan32 {
         assert_eq!(NotNaN::<f32>::min_value(), NotNaN::from(<f32 as Bounded>::min_value()));
         assert_eq!(NotNaN::<f32>::max_value(), NotNaN::from(<f32 as Bounded>::max_value()));
     }
+
+    it "should implement FromPrimitive" {
+        assert_eq!(NotNaN::<f32>::from_i8(42i8), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_u8(42u8), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_i16(42i16), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_u16(42u16), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_i32(42i32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_u32(42u32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_i64(42i64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_u64(42u64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_isize(42isize), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_usize(42usize), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_f32(42f32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_f32(42f32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_f64(42f64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_f64(42f64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f32>::from_f32(Float::nan()), None);
+        assert_eq!(NotNaN::<f32>::from_f64(Float::nan()), None);
+    }
 }
 
 describe! not_nan64 {
@@ -194,6 +213,25 @@ describe! not_nan64 {
     it "should implement Bounded" {
         assert_eq!(NotNaN::<f64>::min_value(), NotNaN::from(<f64 as Bounded>::min_value()));
         assert_eq!(NotNaN::<f64>::max_value(), NotNaN::from(<f64 as Bounded>::max_value()));
+    }
+
+    it "should implement FromPrimitive" {
+        assert_eq!(NotNaN::<f64>::from_i8(42i8), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_u8(42u8), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_i16(42i16), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_u16(42u16), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_i32(42i32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_u32(42u32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_i64(42i64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_u64(42u64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_isize(42isize), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_usize(42usize), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_f32(42f32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_f32(42f32), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_f64(42f64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_f64(42f64), Some(NotNaN::from(42.0)));
+        assert_eq!(NotNaN::<f64>::from_f32(Float::nan()), None);
+        assert_eq!(NotNaN::<f64>::from_f64(Float::nan()), None);
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate ordered_float;
 extern crate num_traits;
 
 pub use ordered_float::*;
-pub use num_traits::{Bounded, Float, FromPrimitive, One, ToPrimitive, Zero};
+pub use num_traits::{Bounded, Float, FromPrimitive, Num, One, ToPrimitive, Zero};
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 
@@ -155,6 +155,11 @@ describe! not_nan32 {
         assert_eq!(x.to_f64(), Some(42f64));
         assert_eq!(x.to_f64(), Some(42f64));
     }
+
+    it "should implement Num" {
+        assert_eq!(NotNaN::<f32>::from_str_radix("42.0", 10).unwrap(), NotNaN::from(42.0f32));
+        assert!(NotNaN::<f32>::from_str_radix("NaN", 10).is_err());
+    }
 }
 
 describe! not_nan64 {
@@ -268,6 +273,11 @@ describe! not_nan64 {
         assert_eq!(x.to_f32(), Some(42f32));
         assert_eq!(x.to_f64(), Some(42f64));
         assert_eq!(x.to_f64(), Some(42f64));
+    }
+
+    it "should implement Num" {
+        assert_eq!(NotNaN::<f64>::from_str_radix("42.0", 10).unwrap(), NotNaN::from(42.0f64));
+        assert!(NotNaN::<f64>::from_str_radix("NaN", 10).is_err());
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -168,6 +168,11 @@ describe! not_nan32 {
         assert_eq!(NotNaN::from(50f32).abs_sub(&NotNaN::from(8f32)), NotNaN::from(42f32));
         assert_eq!(NotNaN::from(8f32).abs_sub(&NotNaN::from(50f32)), NotNaN::from(0f32));
     }
+
+    it "should implement NumCast" {
+        assert_eq!(<NotNaN<f32> as num_traits::NumCast>::from(42), Some(NotNaN::from(42f32)));
+        assert_eq!(<NotNaN<f32> as num_traits::NumCast>::from(f32::nan()), None);
+    }
 }
 
 describe! not_nan64 {
@@ -294,6 +299,11 @@ describe! not_nan64 {
 
         assert_eq!(NotNaN::from(50f64).abs_sub(&NotNaN::from(8f64)), NotNaN::from(42f64));
         assert_eq!(NotNaN::from(8f64).abs_sub(&NotNaN::from(50f64)), NotNaN::from(0f64));
+    }
+
+    it "should implement NumCast" {
+        assert_eq!(<NotNaN<f64> as num_traits::NumCast>::from(42), Some(NotNaN::from(42f64)));
+        assert_eq!(<NotNaN<f64> as num_traits::NumCast>::from(f64::nan()), None);
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate ordered_float;
 extern crate num_traits;
 
 pub use ordered_float::*;
-pub use num_traits::{Bounded, Float};
+pub use num_traits::{Bounded, Float, One, Zero};
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 
@@ -105,6 +105,15 @@ describe! not_nan32 {
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp %= f32::NAN;}).is_err());
     }
 
+    it "should implement Zero" {
+        assert_eq!(NotNaN::<f32>::zero(), NotNaN::from(0.0f32));
+        assert!(NotNaN::<f32>::zero().is_zero());
+    }
+
+    it "should implement One" {
+        assert_eq!(NotNaN::<f32>::one(), NotNaN::from(1.0f32))
+    }
+
     it "should implement Bounded" {
         assert_eq!(NotNaN::<f32>::min_value(), NotNaN::from(<f32 as Bounded>::min_value()));
         assert_eq!(NotNaN::<f32>::max_value(), NotNaN::from(<f32 as Bounded>::max_value()));
@@ -171,6 +180,15 @@ describe! not_nan64 {
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp *= f64::NAN;}).is_err());
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp /= f64::NAN;}).is_err());
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp %= f64::NAN;}).is_err());
+    }
+
+    it "should implement Zero" {
+        assert_eq!(NotNaN::<f64>::zero(), NotNaN::from(0.0f64));
+        assert!(NotNaN::<f64>::zero().is_zero());
+    }
+
+    it "should implement One" {
+        assert_eq!(NotNaN::<f64>::one(), NotNaN::from(1.0f64))
     }
 
     it "should implement Bounded" {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate ordered_float;
 extern crate num_traits;
 
 pub use ordered_float::*;
-pub use num_traits::Float;
+pub use num_traits::{Bounded, Float};
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 
@@ -104,6 +104,11 @@ describe! not_nan32 {
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp /= f32::NAN;}).is_err());
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp %= f32::NAN;}).is_err());
     }
+
+    it "should implement Bounded" {
+        assert_eq!(NotNaN::<f32>::min_value(), NotNaN::from(<f32 as Bounded>::min_value()));
+        assert_eq!(NotNaN::<f32>::max_value(), NotNaN::from(<f32 as Bounded>::max_value()));
+    }
 }
 
 describe! not_nan64 {
@@ -166,6 +171,11 @@ describe! not_nan64 {
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp *= f64::NAN;}).is_err());
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp /= f64::NAN;}).is_err());
         assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp %= f64::NAN;}).is_err());
+    }
+
+    it "should implement Bounded" {
+        assert_eq!(NotNaN::<f64>::min_value(), NotNaN::from(<f64 as Bounded>::min_value()));
+        assert_eq!(NotNaN::<f64>::max_value(), NotNaN::from(<f64 as Bounded>::max_value()));
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate ordered_float;
 extern crate num_traits;
 
 pub use ordered_float::*;
-pub use num_traits::{Bounded, Float, FromPrimitive, Num, One, ToPrimitive, Zero};
+pub use num_traits::{Bounded, Float, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 
@@ -160,6 +160,14 @@ describe! not_nan32 {
         assert_eq!(NotNaN::<f32>::from_str_radix("42.0", 10).unwrap(), NotNaN::from(42.0f32));
         assert!(NotNaN::<f32>::from_str_radix("NaN", 10).is_err());
     }
+
+    it "should implement Signed" {
+        assert_eq!(NotNaN::from(42f32).abs(), NotNaN::from(42f32));
+        assert_eq!(NotNaN::from(-42f32).abs(), NotNaN::from(42f32));
+
+        assert_eq!(NotNaN::from(50f32).abs_sub(&NotNaN::from(8f32)), NotNaN::from(42f32));
+        assert_eq!(NotNaN::from(8f32).abs_sub(&NotNaN::from(50f32)), NotNaN::from(0f32));
+    }
 }
 
 describe! not_nan64 {
@@ -278,6 +286,14 @@ describe! not_nan64 {
     it "should implement Num" {
         assert_eq!(NotNaN::<f64>::from_str_radix("42.0", 10).unwrap(), NotNaN::from(42.0f64));
         assert!(NotNaN::<f64>::from_str_radix("NaN", 10).is_err());
+    }
+
+    it "should implement Signed" {
+        assert_eq!(NotNaN::from(42f64).abs(), NotNaN::from(42f64));
+        assert_eq!(NotNaN::from(-42f64).abs(), NotNaN::from(42f64));
+
+        assert_eq!(NotNaN::from(50f64).abs_sub(&NotNaN::from(8f64)), NotNaN::from(42f64));
+        assert_eq!(NotNaN::from(8f64).abs_sub(&NotNaN::from(50f64)), NotNaN::from(0f64));
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate ordered_float;
 extern crate num_traits;
 
 pub use ordered_float::*;
-pub use num_traits::{Bounded, Float, FromPrimitive, One, Zero};
+pub use num_traits::{Bounded, Float, FromPrimitive, One, ToPrimitive, Zero};
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 
@@ -137,6 +137,24 @@ describe! not_nan32 {
         assert_eq!(NotNaN::<f32>::from_f32(Float::nan()), None);
         assert_eq!(NotNaN::<f32>::from_f64(Float::nan()), None);
     }
+
+    it "should implement ToPrimitive" {
+        let x = NotNaN::from(42.0f32);
+        assert_eq!(x.to_u8(), Some(42u8));
+        assert_eq!(x.to_i8(), Some(42i8));
+        assert_eq!(x.to_u16(), Some(42u16));
+        assert_eq!(x.to_i16(), Some(42i16));
+        assert_eq!(x.to_u32(), Some(42u32));
+        assert_eq!(x.to_i32(), Some(42i32));
+        assert_eq!(x.to_u64(), Some(42u64));
+        assert_eq!(x.to_i64(), Some(42i64));
+        assert_eq!(x.to_usize(), Some(42usize));
+        assert_eq!(x.to_isize(), Some(42isize));
+        assert_eq!(x.to_f32(), Some(42f32));
+        assert_eq!(x.to_f32(), Some(42f32));
+        assert_eq!(x.to_f64(), Some(42f64));
+        assert_eq!(x.to_f64(), Some(42f64));
+    }
 }
 
 describe! not_nan64 {
@@ -232,6 +250,24 @@ describe! not_nan64 {
         assert_eq!(NotNaN::<f64>::from_f64(42f64), Some(NotNaN::from(42.0)));
         assert_eq!(NotNaN::<f64>::from_f32(Float::nan()), None);
         assert_eq!(NotNaN::<f64>::from_f64(Float::nan()), None);
+    }
+
+    it "should implement ToPrimitive" {
+        let x = NotNaN::from(42.0f64);
+        assert_eq!(x.to_u8(), Some(42u8));
+        assert_eq!(x.to_i8(), Some(42i8));
+        assert_eq!(x.to_u16(), Some(42u16));
+        assert_eq!(x.to_i16(), Some(42i16));
+        assert_eq!(x.to_u32(), Some(42u32));
+        assert_eq!(x.to_i32(), Some(42i32));
+        assert_eq!(x.to_u64(), Some(42u64));
+        assert_eq!(x.to_i64(), Some(42i64));
+        assert_eq!(x.to_usize(), Some(42usize));
+        assert_eq!(x.to_isize(), Some(42isize));
+        assert_eq!(x.to_f32(), Some(42f32));
+        assert_eq!(x.to_f32(), Some(42f32));
+        assert_eq!(x.to_f64(), Some(42f64));
+        assert_eq!(x.to_f64(), Some(42f64));
     }
 }
 


### PR DESCRIPTION
This addresses #16. 

The trait `Float` is deliberately *not* implemented for `NotNaN` because of the required methods `nan` and `is_nan`. Unfortunately, this makes many of the useful methods from `Float` unavailable for `NotNaN`, but as long as a `Float` is required to support a NaN-value I do not see a way around it. (Maybe it would be a good idea for `num` to split `Float` into two traits, `Real` and `NaN`, and then `trait Float: Real + NaN`, but this discussion should probably go to `num` itself).