### PR TITLE
Update to unreachable 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/reem/rust-ordered-float"
 [dependencies]
 num-traits = { version = "0.1", default_features = false }
 serde = { version = "1.0", optional = true }
-unreachable = "0.1"
+unreachable = "1.0"
 
 [dev-dependencies]
 stainless = "0.1"


### PR DESCRIPTION
can you release a new version of the `ordered-float` to crates.io? 😉 