### PR TITLE
Update num-traits, unreachable, remove stainless

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "ordered-float"
 version = "0.5.0"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
@@ -8,10 +7,9 @@ description = "Wrappers for total ordering on floats."
 repository = "https://github.com/reem/rust-ordered-float"
 
 [dependencies]
-num-traits = { version = "0.1", default_features = false }
+num-traits = "0.2"
 serde = { version = "1.0", optional = true }
-unreachable = "0.1"
+unreachable = "1"
 
 [dev-dependencies]
-stainless = "0.1"
 serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ impl<T: Float> AsMut<T> for OrderedFloat<T> {
     }
 }
 
-impl<T: Float + PartialOrd> Ord for OrderedFloat<T> {
+impl<T: Float> Ord for OrderedFloat<T> {
     fn cmp(&self, other: &OrderedFloat<T>) -> Ordering {
         match self.partial_cmp(&other) {
             Some(ordering) => ordering,
@@ -77,7 +77,7 @@ impl<T: Float + PartialOrd> Ord for OrderedFloat<T> {
 impl<T: Float + PartialEq> PartialEq for OrderedFloat<T> {
     fn eq(&self, other: &OrderedFloat<T>) -> bool {
         if self.as_ref().is_nan() {
-            if other.as_ref().is_nan() { true } else { false }
+            other.as_ref().is_nan()
         } else if other.as_ref().is_nan() {
             false
         } else {
@@ -176,7 +176,7 @@ impl<T: Float> AsRef<T> for NotNaN<T> {
     }
 }
 
-impl<T: Float + PartialOrd> Ord for NotNaN<T> {
+impl<T: Float> Ord for NotNaN<T> {
     fn cmp(&self, other: &NotNaN<T>) -> Ordering {
         match self.partial_cmp(&other) {
             Some(ord) => ord,
@@ -522,7 +522,7 @@ pub struct FloatIsNaN;
 
 impl Error for FloatIsNaN {
     fn description(&self) -> &str {
-        return "NotNaN constructed with NaN";
+        "NotNaN constructed with NaN"
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,226 +1,325 @@
-#![feature(plugin)]
-#![plugin(stainless)]
-
-extern crate ordered_float;
 extern crate num_traits;
+extern crate ordered_float;
 
-pub use ordered_float::*;
 pub use num_traits::Float;
+pub use ordered_float::*;
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 
-pub use std::collections::HashSet;
 pub use std::collections::hash_map::RandomState;
+pub use std::collections::HashSet;
 pub use std::hash::*;
 
-describe! ordered_float32 {
-    it "should compare regular floats" {
-        assert_eq!(OrderedFloat(7.0f32).cmp(&OrderedFloat(7.0)), Equal);
-        assert_eq!(OrderedFloat(8.0f32).cmp(&OrderedFloat(7.0)), Greater);
-        assert_eq!(OrderedFloat(4.0f32).cmp(&OrderedFloat(7.0)), Less);
-    }
-
-    it "should compare NaN" {
-        let f32_nan: f32 = Float::nan();
-        assert_eq!(OrderedFloat(f32_nan).cmp(&OrderedFloat(Float::nan())), Equal);
-        assert_eq!(OrderedFloat(f32_nan).cmp(&OrderedFloat(-100000.0f32)), Greater);
-        assert_eq!(OrderedFloat(-100.0f32).cmp(&OrderedFloat(Float::nan())), Less);
-    }
+#[test]
+fn ordered_f32_compare_regular_floats() {
+    assert_eq!(OrderedFloat(7.0f32).cmp(&OrderedFloat(7.0)), Equal);
+    assert_eq!(OrderedFloat(8.0f32).cmp(&OrderedFloat(7.0)), Greater);
+    assert_eq!(OrderedFloat(4.0f32).cmp(&OrderedFloat(7.0)), Less);
 }
 
-describe! ordered_float64 {
-    it "should compare regular floats" {
-        assert_eq!(OrderedFloat(7.0f64).cmp(&OrderedFloat(7.0)), Equal);
-        assert_eq!(OrderedFloat(8.0f64).cmp(&OrderedFloat(7.0)), Greater);
-        assert_eq!(OrderedFloat(4.0f64).cmp(&OrderedFloat(7.0)), Less);
-    }
-
-    it "should compare NaN" {
-        let f64_nan: f64 = Float::nan();
-        assert_eq!(OrderedFloat(f64_nan).cmp(&OrderedFloat(Float::nan())), Equal);
-        assert_eq!(OrderedFloat(f64_nan).cmp(&OrderedFloat(-100000.0f64)), Greater);
-        assert_eq!(OrderedFloat(-100.0f64).cmp(&OrderedFloat(Float::nan())), Less);
-    }
+#[test]
+fn ordered_f32_compare_nan() {
+    let f32_nan: f32 = Float::nan();
+    assert_eq!(
+        OrderedFloat(f32_nan).cmp(&OrderedFloat(Float::nan())),
+        Equal
+    );
+    assert_eq!(
+        OrderedFloat(f32_nan).cmp(&OrderedFloat(-100000.0f32)),
+        Greater
+    );
+    assert_eq!(
+        OrderedFloat(-100.0f32).cmp(&OrderedFloat(Float::nan())),
+        Less
+    );
 }
 
-describe! not_nan32 {
-    it "should compare regular floats" {
-        assert_eq!(NotNaN::from(7.0f32).cmp(&NotNaN::from(7.0)), Equal);
-        assert_eq!(NotNaN::from(8.0f32).cmp(&NotNaN::from(7.0)), Greater);
-        assert_eq!(NotNaN::from(4.0f32).cmp(&NotNaN::from(7.0)), Less);
-    }
-
-    it "should fail when constructing NotNaN with NaN" {
-        let f32_nan: f32 = Float::nan();
-        assert!(NotNaN::new(f32_nan).is_err());
-    }
-    
-    it "should calculate correctly" {
-        assert_eq!(*(NotNaN::from(5.0f32) + NotNaN::from(4.0f32)), 5.0f32 + 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) + 4.0f32), 5.0f32 + 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) - NotNaN::from(4.0f32)), 5.0f32 - 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) - 4.0f32), 5.0f32 - 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) * NotNaN::from(4.0f32)), 5.0f32 * 4.0f32);
-        assert_eq!(*(NotNaN::from(5.0f32) * 4.0f32), 5.0f32 * 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) / NotNaN::from(4.0f32)), 8.0f32 / 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) / 4.0f32), 8.0f32 / 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) % NotNaN::from(4.0f32)), 8.0f32 % 4.0f32);
-        assert_eq!(*(NotNaN::from(8.0f32) % 4.0f32), 8.0f32 % 4.0f32);
-        assert_eq!(*(-NotNaN::from(1.0f32)), -1.0f32);
-        
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) + f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) - f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) * f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) / f32::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f32) % f32::NAN}).is_err());
-        
-        let mut number = NotNaN::from(5.0f32);
-        number += NotNaN::from(4.0f32);
-        assert_eq!(*number, 9.0f32);
-        number -= NotNaN::from(4.0f32);
-        assert_eq!(*number, 5.0f32);
-        number *= NotNaN::from(4.0f32);
-        assert_eq!(*number, 20.0f32);
-        number /= NotNaN::from(4.0f32);
-        assert_eq!(*number, 5.0f32);
-        number %= NotNaN::from(4.0f32);
-        assert_eq!(*number, 1.0f32);
-        
-        number = NotNaN::from(5.0f32);
-        number += 4.0f32;
-        assert_eq!(*number, 9.0f32);
-        number -= 4.0f32;
-        assert_eq!(*number, 5.0f32);
-        number *= 4.0f32;
-        assert_eq!(*number, 20.0f32);
-        number /= 4.0f32;
-        assert_eq!(*number, 5.0f32);
-        number %= 4.0f32;
-        assert_eq!(*number, 1.0f32);
-        
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp += f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp -= f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp *= f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp /= f32::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f32); tmp %= f32::NAN;}).is_err());
-    }
+#[test]
+fn ordered_f64_compare_regular_floats() {
+    assert_eq!(OrderedFloat(7.0f64).cmp(&OrderedFloat(7.0)), Equal);
+    assert_eq!(OrderedFloat(8.0f64).cmp(&OrderedFloat(7.0)), Greater);
+    assert_eq!(OrderedFloat(4.0f64).cmp(&OrderedFloat(7.0)), Less);
 }
 
-describe! not_nan64 {
-    it "should compare regular floats" {
-        assert_eq!(NotNaN::from(7.0f64).cmp(&NotNaN::from(7.0)), Equal);
-        assert_eq!(NotNaN::from(8.0f64).cmp(&NotNaN::from(7.0)), Greater);
-        assert_eq!(NotNaN::from(4.0f64).cmp(&NotNaN::from(7.0)), Less);
-    }
-
-    it "should fail when constructing NotNaN with NaN" {
-        let f64_nan: f64 = Float::nan();
-        assert!(NotNaN::new(f64_nan).is_err());
-    }
-    
-    it "should calculate correctly" {
-        assert_eq!(*(NotNaN::from(5.0f64) + NotNaN::from(4.0f64)), 5.0f64 + 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) + 4.0f64), 5.0f64 + 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) - NotNaN::from(4.0f64)), 5.0f64 - 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) - 4.0f64), 5.0f64 - 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) * NotNaN::from(4.0f64)), 5.0f64 * 4.0f64);
-        assert_eq!(*(NotNaN::from(5.0f64) * 4.0f64), 5.0f64 * 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) / NotNaN::from(4.0f64)), 8.0f64 / 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) / 4.0f64), 8.0f64 / 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) % NotNaN::from(4.0f64)), 8.0f64 % 4.0f64);
-        assert_eq!(*(NotNaN::from(8.0f64) % 4.0f64), 8.0f64 % 4.0f64);
-        assert_eq!(*(-NotNaN::from(1.0f64)), -1.0f64);
-        
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) + f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) - f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) * f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) / f64::NAN}).is_err());
-        assert!(panic::catch_unwind(|| {NotNaN::from(0.0f64) % f64::NAN}).is_err());
-        
-        let mut number = NotNaN::from(5.0f64);
-        number += NotNaN::from(4.0f64);
-        assert_eq!(*number, 9.0f64);
-        number -= NotNaN::from(4.0f64);
-        assert_eq!(*number, 5.0f64);
-        number *= NotNaN::from(4.0f64);
-        assert_eq!(*number, 20.0f64);
-        number /= NotNaN::from(4.0f64);
-        assert_eq!(*number, 5.0f64);
-        number %= NotNaN::from(4.0f64);
-        assert_eq!(*number, 1.0f64);
-        
-        number = NotNaN::from(5.0f64);
-        number += 4.0f64;
-        assert_eq!(*number, 9.0f64);
-        number -= 4.0f64;
-        assert_eq!(*number, 5.0f64);
-        number *= 4.0f64;
-        assert_eq!(*number, 20.0f64);
-        number /= 4.0f64;
-        assert_eq!(*number, 5.0f64);
-        number %= 4.0f64;
-        assert_eq!(*number, 1.0f64);
-        
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp += f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp -= f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp *= f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp /= f64::NAN;}).is_err());
-        assert!(panic::catch_unwind(|| {let mut tmp = NotNaN::from(0.0f64); tmp %= f64::NAN;}).is_err());
-    }
+#[test]
+fn ordered_f64_compare_nan() {
+    let f64_nan: f64 = Float::nan();
+    assert_eq!(
+        OrderedFloat(f64_nan).cmp(&OrderedFloat(Float::nan())),
+        Equal
+    );
+    assert_eq!(
+        OrderedFloat(f64_nan).cmp(&OrderedFloat(-100000.0f64)),
+        Greater
+    );
+    assert_eq!(
+        OrderedFloat(-100.0f64).cmp(&OrderedFloat(Float::nan())),
+        Less
+    );
 }
 
-describe! hashing {
-    it "should hash zero and neg-zero to the same hc" {
-        let state = RandomState::new();
-        let mut h1 = state.build_hasher();
-        let mut h2 = state.build_hasher();
-        OrderedFloat::from(0f64).hash(&mut h1);
-        OrderedFloat::from(-0f64).hash(&mut h2);
-        assert_eq!(h1.finish(), h2.finish());
+#[test]
+fn not_nan32_compare_regular_floats() {
+    assert_eq!(NotNaN::from(7.0f32).cmp(&NotNaN::from(7.0)), Equal);
+    assert_eq!(NotNaN::from(8.0f32).cmp(&NotNaN::from(7.0)), Greater);
+    assert_eq!(NotNaN::from(4.0f32).cmp(&NotNaN::from(7.0)), Less);
+}
+
+#[test]
+fn not_nan32_fail_when_constructing_with_nan() {
+    let f32_nan: f32 = Float::nan();
+    assert!(NotNaN::new(f32_nan).is_err());
+}
+
+#[test]
+fn not_nan32_calculate_correctly() {
+    assert_eq!(
+        *(NotNaN::from(5.0f32) + NotNaN::from(4.0f32)),
+        5.0f32 + 4.0f32
+    );
+    assert_eq!(*(NotNaN::from(5.0f32) + 4.0f32), 5.0f32 + 4.0f32);
+    assert_eq!(
+        *(NotNaN::from(5.0f32) - NotNaN::from(4.0f32)),
+        5.0f32 - 4.0f32
+    );
+    assert_eq!(*(NotNaN::from(5.0f32) - 4.0f32), 5.0f32 - 4.0f32);
+    assert_eq!(
+        *(NotNaN::from(5.0f32) * NotNaN::from(4.0f32)),
+        5.0f32 * 4.0f32
+    );
+    assert_eq!(*(NotNaN::from(5.0f32) * 4.0f32), 5.0f32 * 4.0f32);
+    assert_eq!(
+        *(NotNaN::from(8.0f32) / NotNaN::from(4.0f32)),
+        8.0f32 / 4.0f32
+    );
+    assert_eq!(*(NotNaN::from(8.0f32) / 4.0f32), 8.0f32 / 4.0f32);
+    assert_eq!(
+        *(NotNaN::from(8.0f32) % NotNaN::from(4.0f32)),
+        8.0f32 % 4.0f32
+    );
+    assert_eq!(*(NotNaN::from(8.0f32) % 4.0f32), 8.0f32 % 4.0f32);
+    assert_eq!(*(-NotNaN::from(1.0f32)), -1.0f32);
+
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f32) + f32::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f32) - f32::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f32) * f32::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f32) / f32::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f32) % f32::NAN).is_err());
+
+    let mut number = NotNaN::from(5.0f32);
+    number += NotNaN::from(4.0f32);
+    assert_eq!(*number, 9.0f32);
+    number -= NotNaN::from(4.0f32);
+    assert_eq!(*number, 5.0f32);
+    number *= NotNaN::from(4.0f32);
+    assert_eq!(*number, 20.0f32);
+    number /= NotNaN::from(4.0f32);
+    assert_eq!(*number, 5.0f32);
+    number %= NotNaN::from(4.0f32);
+    assert_eq!(*number, 1.0f32);
+
+    number = NotNaN::from(5.0f32);
+    number += 4.0f32;
+    assert_eq!(*number, 9.0f32);
+    number -= 4.0f32;
+    assert_eq!(*number, 5.0f32);
+    number *= 4.0f32;
+    assert_eq!(*number, 20.0f32);
+    number /= 4.0f32;
+    assert_eq!(*number, 5.0f32);
+    number %= 4.0f32;
+    assert_eq!(*number, 1.0f32);
+
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f32);
+            tmp += f32::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f32);
+            tmp -= f32::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f32);
+            tmp *= f32::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f32);
+            tmp /= f32::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f32);
+            tmp %= f32::NAN;
+        }).is_err()
+    );
+}
+
+#[test]
+fn not_nan64_compare_regular_floats() {
+    assert_eq!(NotNaN::from(7.0f64).cmp(&NotNaN::from(7.0)), Equal);
+    assert_eq!(NotNaN::from(8.0f64).cmp(&NotNaN::from(7.0)), Greater);
+    assert_eq!(NotNaN::from(4.0f64).cmp(&NotNaN::from(7.0)), Less);
+}
+
+#[test]
+fn not_nan64_fail_when_constructing_with_nan() {
+    let f64_nan: f64 = Float::nan();
+    assert!(NotNaN::new(f64_nan).is_err());
+}
+
+#[test]
+fn not_nan64_calculate_correctly() {
+    assert_eq!(
+        *(NotNaN::from(5.0f64) + NotNaN::from(4.0f64)),
+        5.0f64 + 4.0f64
+    );
+    assert_eq!(*(NotNaN::from(5.0f64) + 4.0f64), 5.0f64 + 4.0f64);
+    assert_eq!(
+        *(NotNaN::from(5.0f64) - NotNaN::from(4.0f64)),
+        5.0f64 - 4.0f64
+    );
+    assert_eq!(*(NotNaN::from(5.0f64) - 4.0f64), 5.0f64 - 4.0f64);
+    assert_eq!(
+        *(NotNaN::from(5.0f64) * NotNaN::from(4.0f64)),
+        5.0f64 * 4.0f64
+    );
+    assert_eq!(*(NotNaN::from(5.0f64) * 4.0f64), 5.0f64 * 4.0f64);
+    assert_eq!(
+        *(NotNaN::from(8.0f64) / NotNaN::from(4.0f64)),
+        8.0f64 / 4.0f64
+    );
+    assert_eq!(*(NotNaN::from(8.0f64) / 4.0f64), 8.0f64 / 4.0f64);
+    assert_eq!(
+        *(NotNaN::from(8.0f64) % NotNaN::from(4.0f64)),
+        8.0f64 % 4.0f64
+    );
+    assert_eq!(*(NotNaN::from(8.0f64) % 4.0f64), 8.0f64 % 4.0f64);
+    assert_eq!(*(-NotNaN::from(1.0f64)), -1.0f64);
+
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f64) + f64::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f64) - f64::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f64) * f64::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f64) / f64::NAN).is_err());
+    assert!(panic::catch_unwind(|| NotNaN::from(0.0f64) % f64::NAN).is_err());
+
+    let mut number = NotNaN::from(5.0f64);
+    number += NotNaN::from(4.0f64);
+    assert_eq!(*number, 9.0f64);
+    number -= NotNaN::from(4.0f64);
+    assert_eq!(*number, 5.0f64);
+    number *= NotNaN::from(4.0f64);
+    assert_eq!(*number, 20.0f64);
+    number /= NotNaN::from(4.0f64);
+    assert_eq!(*number, 5.0f64);
+    number %= NotNaN::from(4.0f64);
+    assert_eq!(*number, 1.0f64);
+
+    number = NotNaN::from(5.0f64);
+    number += 4.0f64;
+    assert_eq!(*number, 9.0f64);
+    number -= 4.0f64;
+    assert_eq!(*number, 5.0f64);
+    number *= 4.0f64;
+    assert_eq!(*number, 20.0f64);
+    number /= 4.0f64;
+    assert_eq!(*number, 5.0f64);
+    number %= 4.0f64;
+    assert_eq!(*number, 1.0f64);
+
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f64);
+            tmp += f64::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f64);
+            tmp -= f64::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f64);
+            tmp *= f64::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f64);
+            tmp /= f64::NAN;
+        }).is_err()
+    );
+    assert!(
+        panic::catch_unwind(|| {
+            let mut tmp = NotNaN::from(0.0f64);
+            tmp %= f64::NAN;
+        }).is_err()
+    );
+}
+
+#[test]
+fn hash_zero_and_neg_zero_to_the_same_hc() {
+    let state = RandomState::new();
+    let mut h1 = state.build_hasher();
+    let mut h2 = state.build_hasher();
+    OrderedFloat::from(0f64).hash(&mut h1);
+    OrderedFloat::from(-0f64).hash(&mut h2);
+    assert_eq!(h1.finish(), h2.finish());
+}
+
+#[test]
+fn hash_inf_and_neg_inf_to_different_hcs() {
+    let state = RandomState::new();
+    let mut h1 = state.build_hasher();
+    let mut h2 = state.build_hasher();
+    OrderedFloat::from(f64::INFINITY).hash(&mut h1);
+    OrderedFloat::from(f64::NEG_INFINITY).hash(&mut h2);
+    assert!(h1.finish() != h2.finish());
+}
+
+#[test]
+fn hash_is_good_for_whole_numbers() {
+    let state = RandomState::new();
+    let limit = 10000;
+
+    let mut set = ::std::collections::HashSet::with_capacity(limit);
+    for i in 0..limit {
+        let mut h = state.build_hasher();
+        OrderedFloat::from(i as f64).hash(&mut h);
+        set.insert(h.finish());
     }
 
-    it "should hash inf and neg-inf to different hcs" {
-        let state = RandomState::new();
-        let mut h1 = state.build_hasher();
-        let mut h2 = state.build_hasher();
-        OrderedFloat::from(f64::INFINITY).hash(&mut h1);
-        OrderedFloat::from(f64::NEG_INFINITY).hash(&mut h2);
-        assert!(h1.finish() != h2.finish());
+    // This allows 100 collisions, which is far too
+    // many, but should guard against transient issues
+    // that will result from using RandomState
+    let pct_unique = set.len() as f64 / limit as f64;
+    assert!(0.99f64 < pct_unique, "percent-unique={}", pct_unique);
+}
+
+#[test]
+fn hash_is_good_for_fractional_numbers() {
+    let state = RandomState::new();
+    let limit = 10000;
+
+    let mut set = ::std::collections::HashSet::with_capacity(limit);
+    for i in 0..limit {
+        let mut h = state.build_hasher();
+        OrderedFloat::from(i as f64 * (1f64 / limit as f64)).hash(&mut h);
+        set.insert(h.finish());
     }
 
-    it "should have a good hash function for whole numbers" {
-        let state = RandomState::new();
-        let limit = 10000;
-
-        let mut set = ::std::collections::HashSet::with_capacity(limit);
-        for i in 0..limit {
-            let mut h = state.build_hasher();
-            OrderedFloat::from(i as f64).hash(&mut h);
-            set.insert(h.finish());
-        }
-
-        // This allows 100 collisions, which is far too
-        // many, but should guard against transient issues
-        // that will result from using RandomState
-        let pct_unique = set.len() as f64 / limit as f64;
-        assert!(0.99f64 < pct_unique, "percent-unique={}", pct_unique);
-    }
-
-    it "should have a good hash function for fractional numbers" {
-        let state = RandomState::new();
-        let limit = 10000;
-
-        let mut set = ::std::collections::HashSet::with_capacity(limit);
-        for i in 0..limit {
-            let mut h = state.build_hasher();
-            OrderedFloat::from(i as f64 * (1f64 / limit as f64)).hash(&mut h);
-            set.insert(h.finish());
-        }
-
-        // This allows 100 collisions, which is far too
-        // many, but should guard against transient issues
-        // that will result from using RandomState
-        let pct_unique = set.len() as f64 / limit as f64;
-        assert!(0.99f64 < pct_unique, "percent-unique={}", pct_unique);
-    }
+    // This allows 100 collisions, which is far too
+    // many, but should guard against transient issues
+    // that will result from using RandomState
+    let pct_unique = set.len() as f64 / limit as f64;
+    assert!(0.99f64 < pct_unique, "percent-unique={}", pct_unique);
 }


### PR DESCRIPTION
* Update to current num-traits using default features as that's just _std_ and is required for `Float`.
* Remove stainless & flatten the tests into regular style so they'd run with the current compiler.
* Update unreachable