### PR TITLE
In no_std context, use no_std num-traits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["no_std", "ord", "f64", "f32", "sort"]
 categories = ["science", "rust-patterns", "no-std"]
 
 [dependencies]
-num-traits = "0.2"
+num-traits = { version = "0.2.1", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -18,4 +18,4 @@ serde_test = "1.0"
 
 [features]
 default = ["std"]
-std = []
+std = ["num-traits/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,11 @@ use core::mem;
 use core::hint::unreachable_unchecked;
 use core::str::FromStr;
 
-use num_traits::{Bounded, Float, FromPrimitive, Num, NumCast, One, Signed, ToPrimitive,
-                 Zero};
+use num_traits::{Bounded, FromPrimitive, Num, NumCast, One, Signed, ToPrimitive, Zero};
+#[cfg(feature = "std")]
+use num_traits::Float;
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore as Float;
 
 /// A wrapper around Floats providing an implementation of Ord and Hash.
 ///
@@ -615,7 +618,7 @@ impl<T: Float + Signed> Signed for NotNan<T> {
     fn abs(&self) -> Self { NotNan(self.0.abs()) }
 
     fn abs_sub(&self, other: &Self) -> Self {
-        NotNan::new(self.0.abs_sub(other.0)).expect("Subtraction resulted in NaN")
+        NotNan::new(Signed::abs_sub(&self.0, &other.0)).expect("Subtraction resulted in NaN")
     }
 
     fn signum(&self) -> Self { NotNan(self.0.signum()) }
@@ -635,7 +638,10 @@ mod impl_serde {
     use self::serde::{Serialize, Serializer, Deserialize, Deserializer};
     use self::serde::de::{Error, Unexpected};
     use super::{OrderedFloat, NotNan};
+    #[cfg(feature = "std")]
     use num_traits::Float;
+    #[cfg(not(feature = "std"))]
+    use num_traits::float::FloatCore as Float;
     use core::f64;
 
     #[cfg(test)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,7 +2,12 @@ extern crate num_traits;
 extern crate ordered_float;
 
 pub use ordered_float::*;
-pub use num_traits::{Bounded, Float, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+pub use num_traits::{Bounded, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+#[cfg(feature = "std")]
+pub use num_traits::Float;
+#[cfg(not(feature = "std"))]
+pub use num_traits::float::FloatCore as Float;
+
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 

--- a/tests/test_deprecated_names.rs
+++ b/tests/test_deprecated_names.rs
@@ -4,7 +4,11 @@ extern crate num_traits;
 extern crate ordered_float;
 
 pub use ordered_float::*;
-pub use num_traits::{Bounded, Float, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+pub use num_traits::{Bounded, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+#[cfg(feature = "std")]
+pub use num_traits::Float;
+#[cfg(not(feature = "std"))]
+pub use num_traits::float::FloatCore as Float;
 pub use std::cmp::Ordering::*;
 pub use std::{f32, f64, panic};
 


### PR DESCRIPTION
This crate was not actually no_std compatible because it (1) used
num-traits with the `std` feature, and (2) relied on the `Float` trait,
which is unavailable in no_std.

I have altered it to rely on `FloatCore` instead and passed the feature
flag through to the dependency.

Had to bump the version of num-traits required, because FloatCore only
appeared in 0.2.1.