### PR TITLE
Change unchecked_new to use const fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,16 @@ impl<T: Float> Zero for OrderedFloat<T> {
 /// A NaN value cannot be stored in this type.
 #[derive(PartialOrd, PartialEq, Debug, Default, Clone, Copy)]
 #[repr(transparent)]
-pub struct NotNan<T: Float>(T);
+pub struct NotNan<T>(T);
+
+impl<T> NotNan<T> {
+    /// Create a NotNan value from a value that is guaranteed to not be NaN
+    ///
+    /// Behaviour is undefined if `val` is NaN
+    pub const unsafe fn unchecked_new(val: T) -> Self {
+        NotNan(val)
+    }
+}
 
 impl<T: Float> NotNan<T> {
     /// Create a NotNan value.
@@ -249,14 +258,6 @@ impl<T: Float> NotNan<T> {
             ref val if val.is_nan() => Err(FloatIsNan),
             val => Ok(NotNan(val)),
         }
-    }
-
-    /// Create a NotNan value from a value that is guaranteed to not be NaN
-    ///
-    /// Behaviour is undefined if `val` is NaN
-    pub unsafe fn unchecked_new(val: T) -> Self {
-        debug_assert!(!val.is_nan());
-        NotNan(val)
     }
 
     /// Get the value out.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -579,3 +579,10 @@ fn not_nan64_sum_product() {
     assert_eq!([a,b,c].iter().product::<NotNan<_>>(), a * b * c);
 
 }
+
+#[test]
+fn not_nan_usage_in_const_context() {
+    const A: NotNan<f32> = unsafe { NotNan::unchecked_new(111f32) };
+ 
+    assert_eq!(A, NotNan::new(111f32).unwrap());
+}


### PR DESCRIPTION
This solves #67 by changing `NotNan::unchecked_new()` to use `const fn`, allowing its usage in const contexts.

The only real API change, other than the `const fn`, is that the structural bound for `NotNan<T>` is no longer limited to `T: Float`. However, all of the `impl` blocks for `NotNan<T>` still require `T: Float`. This should allow the `const fn` while also minimizing the change in behavior.

I also removed the `debug_assert!()` statement from the function, since allowing `if` statements in a const context would force the MSRV to bump up by quite a few versions. If this is acceptable I will add it back.