### PR TITLE
Add optional JsonSchema support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,12 @@ jobs:
           command: test
           args: --no-default-features
 
+      - name: Test (schema features subset)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features "std,schemars"
+
       - name: Test (all features)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 num-traits = { version = "0.2.1", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
+schemars = { version = "0.6.5", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"


### PR DESCRIPTION
Hello @mbrubeck , @reem et al, thanks for this useful library.  Here's a feature enhancement that could help out.

## Motivating Use Case

I would like to use types from `ordered-float` in one of my JSON APIs.  The JSON API has a constraint that all involved types must implement `JsonSchema` from the [schemars](https://github.com/GREsau/schemars/) crate in order to wire up autogeneration of JSON schema for API documentation and discoverability.

## Implementation Details

`schemars` is added as an optional dependency. Implementations of `JsonSchema` for `OrderedFloat<f32|f64>` and `NotNan<f32|f64>` are provided behind feature flag gating. Both "std" and "schemars" features are required, as the `schemars` crate is firmly `std`-only.

The provided schema match the pre-existing `serde` implementations which serialize the underlying float value without any additional structure.

Relevant unit tests have been added as well.