### PR TITLE
Implement traits from the 'rand' crate.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.34.0
+          - 1.36.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,27 @@
 [package]
-name = "ordered-float"
-version = "2.4.0"
-authors = ["Jonathan Reem <jonathan.reem@gmail.com>", "Matt Brubeck <mbrubeck@limpet.net>"]
-license = "MIT"
+name        = "ordered-float"
+version     = "2.4.0"
+authors     = [
+  "Jonathan Reem <jonathan.reem@gmail.com>",
+  "Matt Brubeck <mbrubeck@limpet.net>",
+]
+license     = "MIT"
 description = "Wrappers for total ordering on floats"
-repository = "https://github.com/reem/rust-ordered-float"
-readme = "README.md"
-keywords = ["no_std", "ord", "f64", "f32", "sort"]
-categories = ["science", "rust-patterns", "no-std"]
-edition = "2018"
+repository  = "https://github.com/reem/rust-ordered-float"
+readme      = "README.md"
+keywords    = ["no_std", "ord", "f64", "f32", "sort"]
+categories  = ["science", "rust-patterns", "no-std"]
+edition     = "2018"
 
 [dependencies]
 num-traits = { version = "0.2.1", default-features = false }
-serde = { version = "1.0", optional = true, default-features = false }
-schemars = { version = "0.6.5", optional = true }
+serde      = { version = "1.0", optional = true, default-features = false }
+schemars   = { version = "0.6.5", optional = true }
+rand       = { version = "0.8.3", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"
 
 [features]
 default = ["std"]
-std = ["num-traits/std"]
+std     = ["num-traits/std", "rand/std", "rand/std_rng"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1298,6 +1298,7 @@ mod impl_rand {
                     UniformSampler::new(low, high)
                 }
                 fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                    // UniformFloat.sample() will never return NaN.
                     unsafe { NotNan::unchecked_new(self.0.sample(rng)) }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1126,7 +1126,7 @@ mod impl_serde {
         fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
             let float = T::deserialize(d)?;
             NotNan::new(float).map_err(|_| {
-                Error::invalid_value(Unexpected::Float(f64::NAN), &"float (but not NaN)")
+                Error::invalid_value(Unexpected::Float(std::f64::NAN), &"float (but not NaN)")
             })
         }
     }
@@ -1146,7 +1146,7 @@ mod impl_serde {
     #[test]
     fn test_fail_on_nan() {
         assert_de_tokens_error::<NotNan<f64>>(
-            &[Token::F64(f64::NAN)],
+            &[Token::F64(std::f64::NAN)],
             "invalid value: floating point `NaN`, expected float (but not NaN)");
     }
 }
@@ -1363,7 +1363,7 @@ mod impl_rand {
     #[test]
     #[should_panic]
     fn uniform_sampling_panic_on_infinity_notnan() {
-        let (low, high) = (NotNan::new(0f64).unwrap(), NotNan::new(f64::INFINITY).unwrap());
+        let (low, high) = (NotNan::new(0f64).unwrap(), NotNan::new(std::f64::INFINITY).unwrap());
         let uniform = Uniform::new(low,high);
         let _ = uniform.sample(&mut rand::thread_rng());
     }
@@ -1371,7 +1371,7 @@ mod impl_rand {
     #[test]
     #[should_panic]
     fn uniform_sampling_panic_on_infinity_ordered() {
-        let (low, high) = (OrderedFloat(0f64), OrderedFloat(f64::INFINITY));
+        let (low, high) = (OrderedFloat(0f64), OrderedFloat(std::f64::INFINITY));
         let uniform = Uniform::new(low,high);
         let _ = uniform.sample(&mut rand::thread_rng());
     }
@@ -1379,7 +1379,7 @@ mod impl_rand {
     #[test]
     #[should_panic]
     fn uniform_sampling_panic_on_nan_ordered() {
-        let (low, high) = (OrderedFloat(0f64), OrderedFloat(f64::NAN));
+        let (low, high) = (OrderedFloat(0f64), OrderedFloat(std::f64::NAN));
         let uniform = Uniform::new(low,high);
         let _ = uniform.sample(&mut rand::thread_rng());
     }


### PR DESCRIPTION
Related issue: #83. Implements sampling in the Standard, Open01, and OpenClosed01 distributions. Uniform sampling is also implemented.

This is my first Rust PR and I wouldn't mind feedback.