### PR TITLE
Implement Arbitrary instances from proptest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ num-traits = { version = "0.2.1", default-features = false }
 serde      = { version = "1.0", optional = true, default-features = false }
 schemars   = { version = "0.6.5", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
+proptest   = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
 
 [features]
-default = ["std"]
-std = ["num-traits/std"]
+default  = ["std"]
+std      = ["num-traits/std"]
 randtest = ["rand/std", "rand/std_rng"]


### PR DESCRIPTION
`proptest` doesn't support `no_std` on stable. Will this cause trouble or is it fine as long as the dependency is optional?