### PR TITLE
Add optional support for rkyv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition     = "2018"
 [dependencies]
 num-traits = { version = "0.2.1", default-features = false }
 serde      = { version = "1.0", optional = true, default-features = false }
+rkyv       = { version = "0.7", optional = true, default-features = false, features = ["size_32"] }
 schemars   = { version = "0.6.5", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
 proptest   = { version = "1.0.0", optional = true }


### PR DESCRIPTION
Similar to serde support this adds optional support for the [`rkyv`](https://github.com/rkyv/rkyv) (de)serialization framework for `OrderedFloat` and `NotNan`. It is feature-gated the same way serde is.

Implementations are based on the trait implementations for primitives from the `rkyv` crate instead of derive macros to avoid the intermediate `ArchivedX` type that doesn't implement the comparison traits.