### PR TITLE
`impl arbitrary::Arbitrary` for `NotNan` and `OrderedFloat`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde      = { version = "1.0", optional = true, default-features = false }
 rkyv       = { version = "0.7", optional = true, default-features = false, features = ["size_32"] }
 schemars   = { version = "0.6.5", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
+arbitrary  = { version = "1.0.0", optional = true }
 proptest   = { version = "1.0.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Adds an implementation of [`arbitrary::Arbitrary`](https://crates.io/crates/arbitrary) for both `OrderedFloat` and `NotNan`. This allows code that uses `ordered-float` to be more easily tested using [`cargo fuzz`](https://github.com/rust-fuzz/cargo-fuzz).

I've been successfully using this algorithm as an explicit function in my own project; adding it as a trait implementation for the type will make it possible to just use `#[derive(Arbitrary)]` on types containing `NotNan` or `OrderedFloat`.

