### PR TITLE
Adds clippy and rustfmt to workflow + small cleanups

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,29 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
 
+      - name: Install rustfmt + clippy
+        if: matrix.rust == 'stable'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: Check Fmt
+        if: matrix.rust == 'stable'
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Check Lints (all features)
+        if: matrix.rust == 'stable'
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --tests --all-features
+
       - name: Test (default features)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition     = "2018"
 num-traits = { version = "0.2.1", default-features = false }
 serde      = { version = "1.0", optional = true, default-features = false }
 rkyv       = { version = "0.7", optional = true, default-features = false, features = ["size_32"] }
-schemars   = { version = "0.6.5", optional = true }
+schemars   = { version = "0.8.8", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
 arbitrary  = { version = "1.0.0", optional = true }
 proptest   = { version = "1.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "ordered-float"
-version     = "2.9.0"
+version     = "2.10.0"
 authors     = [
   "Jonathan Reem <jonathan.reem@gmail.com>",
   "Matt Brubeck <mbrubeck@limpet.net>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,7 +932,7 @@ impl Borrow<f64> for NotNan<f64> {
 #[allow(clippy::derive_ord_xor_partial_ord)]
 impl<T: Float> Ord for NotNan<T> {
     fn cmp(&self, other: &NotNan<T>) -> Ordering {
-        match self.partial_cmp(&other) {
+        match self.partial_cmp(other) {
             Some(ord) => ord,
             None => unsafe { unreachable_unchecked() },
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -665,7 +665,8 @@ fn not_nan_usage_in_const_context() {
 fn not_nan_panic_safety() {
     let catch_op = |mut num, op: fn(&mut NotNan<_>)| {
         let mut num_ref = panic::AssertUnwindSafe(&mut num);
-        let _ = panic::catch_unwind(move || op(*num_ref));
+        #[allow(clippy::needless_borrow)] // mut-borrow needed for msrv 1.36.0
+        let _ = panic::catch_unwind(move || op(&mut *num_ref));
         num
     };
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -665,7 +665,7 @@ fn not_nan_usage_in_const_context() {
 fn not_nan_panic_safety() {
     let catch_op = |mut num, op: fn(&mut NotNan<_>)| {
         let mut num_ref = panic::AssertUnwindSafe(&mut num);
-        let _ = panic::catch_unwind(move || op(&mut *num_ref));
+        let _ = panic::catch_unwind(move || op(*num_ref));
         num
     };
 


### PR DESCRIPTION
This PR adds checks for rustfmt and clippy to the workflow.

The dangling v2.10.0 tag has been merged into master, thereby setting the version in Cargo.toml to 2.10.0. The version fo the `schemars` dependency has also been bumped up to version 0.8.8, the latest version.

1 needless borrow has been removed and another one was allowed and annotated since the msrv 1.36.0 required it.