### PR TITLE
Add bytemuck feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ schemars   = { version = "0.8.8", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
 arbitrary  = { version = "1.0.0", optional = true }
 proptest   = { version = "1.0.0", optional = true }
+bytemuck   = { version = "1.8.0", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2039,3 +2039,21 @@ mod impl_arbitrary {
     }
     impl_arbitrary! { f32, f64 }
 }
+
+#[cfg(feature = "bytemuck")]
+mod impl_bytemuck {
+    use super::{NotNan, OrderedFloat};
+    use bytemuck::{Pod, Zeroable};
+
+    unsafe impl Zeroable for OrderedFloat<f32> {}
+    unsafe impl Zeroable for OrderedFloat<f64> {}
+
+    unsafe impl Zeroable for NotNan<f32> {}
+    unsafe impl Zeroable for NotNan<f64> {}
+
+    unsafe impl Pod for OrderedFloat<f32> {}
+    unsafe impl Pod for OrderedFloat<f64> {}
+
+    unsafe impl Pod for NotNan<f32> {}
+    unsafe impl Pod for NotNan<f64> {}
+}


### PR DESCRIPTION
Mark NotNan and OrderedFloat as compatible with bytemuck::Pod.