### PR TITLE
Add lossy conversion for `NotNan<f64>` to `NotNan<f32>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -958,7 +958,7 @@ impl NotNan<f64> {
     /// Converts this [`NotNan`]`<`[`f64`]`>` to a [`NotNan`]`<`[`f32`]`>` while giving up on
     /// precision, [using `roundTiesToEven` as rounding mode, yielding `Infinity` on
     /// overflow](https://doc.rust-lang.org/reference/expressions/operator-expr.html#semantics).
-    pub fn into_notnan_f32_lossy(self) -> NotNan<f32> {
+    pub fn as_f32(self) -> NotNan<f32> {
         // This is not destroying invariants, as it is a pure rounding operation. The only two special
         // cases are where f32 would be overflowing, then the operation yields Infinity, or where
         // the input is already NaN, in which case the invariant is already broken elsewhere.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -954,6 +954,18 @@ impl<T: Float + fmt::Display> fmt::Display for NotNan<T> {
     }
 }
 
+impl NotNan<f64> {
+    /// Converts this [`NotNan`]`<`[`f64`]`>` to a [`NotNan`]`<`[`f32`]`>` while giving up on
+    /// precision, [using `roundTiesToEven` as rounding mode, yielding `Infinity` on
+    /// overflow](https://doc.rust-lang.org/reference/expressions/operator-expr.html#semantics).
+    pub fn into_notnan_f32_lossy(self) -> NotNan<f32> {
+        // This is not destroying invariants, as it is a pure rounding operation. The only two special
+        // cases are where f32 would be overflowing, then the operation yields Infinity, or where
+        // the input is already NaN, in which case the invariant is already broken elsewhere.
+        NotNan(self.0 as f32)
+    }
+}
+
 impl From<NotNan<f32>> for f32 {
     #[inline]
     fn from(value: NotNan<f32>) -> Self {


### PR DESCRIPTION
Currently, it's not cleanly possible to convert a `NotNan<f64>` to a `NotNan<f32>` if you're aware of the precision loss and are ready to take it without unwrapping and re-wrapping again.

So this PR addresses this through adding a `NotNan::<f64>::into_notnan_f64_lossy` which does that automatically.

I'm not sure about the naming of the method. I'd like to shorten it, and also I'm not sure whether that's a case for using `as_` naming, as the Rust API guidelines suggest.