### PR TITLE
Add scientific notation `Display` impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,20 @@ impl<T: Float + fmt::Display> fmt::Display for OrderedFloat<T> {
     }
 }
 
+impl<T: Float + fmt::LowerExp> fmt::LowerExp for OrderedFloat<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: Float + fmt::UpperExp> fmt::UpperExp for OrderedFloat<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl From<OrderedFloat<f32>> for f32 {
     #[inline]
     fn from(f: OrderedFloat<f32>) -> f32 {


### PR DESCRIPTION
## Description
I just ran into a case where I wanted to format `OrderedFloat`s in scientific notation using `std::fmt::LowerExp` and `std::fmt::UpperExp`. This adds delegate implementations for both of those traits.

## Example:
```rust
use ordered_float::OrderedFloat;

fn main() {
    let n = OrderedFloat(10.2);
    println!("{:+.2e}", n); // prints "+1.02e1"
}
```