### PR TITLE
Add speedy serialization feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ schemars   = { version = "0.8.8", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
 arbitrary  = { version = "1.0.0", optional = true }
 proptest   = { version = "1.0.0", optional = true }
+speedy     = { version = "0.8.3", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ordered Floats
 
-Provides several wrapper types for Ord and Eq implementations on f64.
+Provides several wrapper types for Ord and Eq implementations on f64 and friends.
 
 See the [API documentation](https://docs.rs/ordered-float) for further details.
 
@@ -22,6 +22,8 @@ The following optional features can be enabled in `Cargo.toml`:
 * `serde`: Implements the `serde::Serialize` and `serde::Deserialize` traits.
 * `schemars`: Implements the `schemars::JsonSchema` trait.
 * `proptest`: Implements the `proptest::Arbitrary` trait.
+* `rkyv`: Implements `rkyv`'s `Archive`, `Serialize` and `Deserialize` traits.
+* `speedy`: Implements `speedy`'s `Readable` and `Writable` traits.
 
 ## License
 


### PR DESCRIPTION
This adds an implementation of [`speedy`](https://github.com/koute/speedy)'s `Readable` and `Writable` traits for `OrderedFloat` and `NotNan`.