### PR TITLE
Add support for bytemuck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rand       = { version = "0.8.3", optional = true, default-features = false }
 arbitrary  = { version = "1.0.0", optional = true }
 proptest   = { version = "1.0.0", optional = true }
 speedy     = { version = "0.8.3", optional = true, default-features = false }
+bytemuck   = { version = "1.12.2", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2176,8 +2176,8 @@ mod impl_arbitrary {
 
 #[cfg(feature = "bytemuck")]
 mod impl_bytemuck {
-    use super::{NotNan, OrderedFloat, Float};
-    use bytemuck::{CheckedBitPattern, AnyBitPattern, NoUninit, Pod, Zeroable};
+    use super::{Float, NotNan, OrderedFloat};
+    use bytemuck::{AnyBitPattern, CheckedBitPattern, NoUninit, Pod, Zeroable};
 
     unsafe impl<T: Zeroable> Zeroable for OrderedFloat<T> {}
 


### PR DESCRIPTION
I know that there is already a previous PR (#108) for adding this support for bytemuck. However it seems that it is stuck without any updates for a long time. I tried to fix the code from that PR only implementing `bytemuck::NoUninit` and `bytemuck::CheckedBitPattern` for `NotNan`.

If there is anything that could still be improved in the PR please let me know.