### PR TITLE
Fix split of `rkyv` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition     = "2021"
 [dependencies]
 num-traits = { version = "0.2.1", default-features = false }
 serde      = { version = "1.0", optional = true, default-features = false }
-rkyv       = { version = "0.7", optional = true, default-features = false }
+rkyv_xx    = { version = "0.7", optional = true, default-features = false, package = "rkyv" }
 schemars   = { version = "0.8.8", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
 arbitrary  = { version = "1.0.0", optional = true }
@@ -33,6 +33,6 @@ std      = ["num-traits/std"]
 serde    = ["dep:serde", "rand/serde1"]
 randtest = ["rand/std", "rand/std_rng"]
 rkyv     = ["rkyv_32"]
-rkyv_16  = ["dep:rkyv", "rkyv/size_16"]
-rkyv_32  = ["dep:rkyv", "rkyv/size_32"]
-rkyv_64  = ["dep:rkyv", "rkyv/size_64"]
+rkyv_16  = ["rkyv_xx/size_16"]
+rkyv_32  = ["rkyv_xx/size_32"]
+rkyv_64  = ["rkyv_xx/size_64"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1678,7 +1678,7 @@ mod impl_serde {
     }
 }
 
-#[cfg(feature = "rkyv")]
+#[cfg(feature = "rkyv_xx")]
 mod impl_rkyv {
     use super::{NotNan, OrderedFloat};
     #[cfg(not(feature = "std"))]
@@ -1688,6 +1688,7 @@ mod impl_rkyv {
     #[cfg(test)]
     use rkyv::{archived_root, ser::Serializer};
     use rkyv::{from_archived, Archive, Deserialize, Fallible, Serialize};
+    use rkyv_xx as rkyv;
 
     #[cfg(test)]
     type DefaultSerializer = rkyv::ser::serializers::CoreSerializer<16, 16>;


### PR DESCRIPTION
Sorry, I forgot to actually test `cargo check --features rkyv_64`. It does not work because `rkyv_64 = ["dep:rkyv", "rkyv/size_64"]` treats `rkyv` in  `"rkyv/size_64"` as feature instead of dependency and `"dep:rkyv/size_64"` is invalid. The fix is to avoid namespaced features when we have to enable a dependency of a dependency. I've tried `rkyv_64 = ["dep:rkyv", "rkyv?/size_64"]` as well and it first seems to work but as soon as `ordered-float` is used in another crate it breaks.