### PR TITLE
Support safe `rkyv` API.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,4 +78,4 @@ jobs:
           args: --features ${{ env.all_features }}
 
 env:
-  all_features: "bytemuck,rand,randtest,serde,schemars,proptest,rkyv,speedy"
+  all_features: "bytemuck,rand,randtest,serde,schemars,proptest,rkyv,rkyv_ck,speedy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition     = "2021"
 [dependencies]
 num-traits = { version = "0.2.1", default-features = false }
 serde      = { version = "1.0", optional = true, default-features = false }
-rkyv       = { version = "0.7", optional = true, default-features = false }
+rkyv       = { version = "0.7.41", optional = true, default-features = false }
 schemars   = { version = "0.8.8", optional = true }
 rand       = { version = "0.8.3", optional = true, default-features = false }
 arbitrary  = { version = "1.0.0", optional = true }
@@ -36,3 +36,4 @@ rkyv     = ["rkyv_32"]
 rkyv_16  = ["dep:rkyv", "rkyv?/size_16"]
 rkyv_32  = ["dep:rkyv", "rkyv?/size_32"]
 rkyv_64  = ["dep:rkyv", "rkyv?/size_64"]
+rkyv_ck  = ["rkyv?/validation"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1740,6 +1740,29 @@ mod impl_rkyv {
         }
     }
 
+    #[cfg(feature = "rkyv_ck")]
+    use rkyv::bytecheck::CheckBytes;
+
+    #[cfg(feature = "rkyv_ck")]
+    impl<C: ?Sized, T: CheckBytes<C>> CheckBytes<C> for OrderedFloat<T> {
+        type Error = T::Error;
+
+        #[inline]
+        unsafe fn check_bytes<'a>(value: *const Self, c: &mut C) -> Result<&'a Self, Self::Error> {
+            T::check_bytes(value as *const T, c).map(|_| &*value)
+        }
+    }
+
+    #[cfg(feature = "rkyv_ck")]
+    impl<C: ?Sized, T: CheckBytes<C>> CheckBytes<C> for NotNan<T> {
+        type Error = T::Error;
+
+        #[inline]
+        unsafe fn check_bytes<'a>(value: *const Self, c: &mut C) -> Result<&'a Self, Self::Error> {
+            T::check_bytes(value as *const T, c).map(|_| &*value)
+        }
+    }
+
     #[test]
     fn test_ordered_float() {
         let float = OrderedFloat(1.0f64);


### PR DESCRIPTION
`bytecheck` is re-exported by `rkyv` from `0.7.41` on. Pointers are simply delegated as both types are `transparent`.