### PR TITLE
Refactor hash float

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -456,12 +456,32 @@ fn not_nan64_num_cast() {
 }
 
 #[test]
-fn hash_zero_and_neg_zero_to_the_same_hc() {
+fn hash_zero_and_neg_zero_to_the_same_hc_ordered_float64() {
     let state = RandomState::new();
     let mut h1 = state.build_hasher();
     let mut h2 = state.build_hasher();
     OrderedFloat::from(0f64).hash(&mut h1);
     OrderedFloat::from(-0f64).hash(&mut h2);
+    assert_eq!(h1.finish(), h2.finish());
+}
+
+#[test]
+fn hash_zero_and_neg_zero_to_the_same_hc_not_nan32() {
+    let state = RandomState::new();
+    let mut h1 = state.build_hasher();
+    let mut h2 = state.build_hasher();
+    NotNan::try_from(0f32).unwrap().hash(&mut h1);
+    NotNan::try_from(-0f32).unwrap().hash(&mut h2);
+    assert_eq!(h1.finish(), h2.finish());
+}
+
+#[test]
+fn hash_different_nans_to_the_same_hc() {
+    let state = RandomState::new();
+    let mut h1 = state.build_hasher();
+    let mut h2 = state.build_hasher();
+    OrderedFloat::from(f64::nan()).hash(&mut h1);
+    OrderedFloat::from(-f64::nan()).hash(&mut h2);
     assert_eq!(h1.finish(), h2.finish());
 }
 


### PR DESCRIPTION
Hi!

I noticed that for hashing ordered floats, we normalize NaN to a unique representation, just to later check for .is_nan() in raw_double_bits anyway.

Also, for NotNan, we have this .is_nan() check in raw_double_bits, even though it can never be true due to the NotNan invariant.

So I decided to try to restructure the hashing code a bit. The special cases are now all handled uniformly inside the hash implementations, and raw_double_bits just does the raw bit conversion, without any special handling.

I took care to not change the actual resulting hashes, in case that's relevant for backwards compatibility.

Also, I added a test case for mapping 0 and -0 for NotNan to the same hash, and one for mapping different representations of NaN for OrderedFloat to the same hash.