### PR TITLE
Pow support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,11 @@ use core::str::FromStr;
 
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore as Float;
-#[cfg(feature = "std")]
-pub use num_traits::Float;
 use num_traits::{
-    AsPrimitive, Bounded, FloatConst, FromPrimitive, Num, NumCast, One, Pow, Signed, ToPrimitive,
-    Zero,
+    AsPrimitive, Bounded, FloatConst, FromPrimitive, Num, NumCast, One, Signed, ToPrimitive, Zero,
 };
+#[cfg(feature = "std")]
+pub use num_traits::{Float, Pow};
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,6 +408,22 @@ impl_ordered_float_pow! {f32, f32, OrderedFloat::from_f32}
 impl_ordered_float_pow! {f64, f32, OrderedFloat::from_f64}
 impl_ordered_float_pow! {f64, f64, OrderedFloat::from_f64}
 
+macro_rules! impl_ordered_float_self_pow {
+    ($base:ty, $exp:ty) => {
+        impl Pow<OrderedFloat<$exp>> for OrderedFloat<$base> {
+            type Output = OrderedFloat<$base>;
+            #[inline]
+            fn pow(self, rhs: OrderedFloat<$exp>) -> OrderedFloat<$base> {
+                OrderedFloat(<$base>::pow(self.0, rhs.0))
+            }
+        }
+    };
+}
+
+impl_ordered_float_self_pow! {f32, f32}
+impl_ordered_float_self_pow! {f64, f32}
+impl_ordered_float_self_pow! {f64, f64}
+
 /// Adds a float directly.
 impl<T: Float + Sum> Sum for OrderedFloat<T> {
     fn sum<I: Iterator<Item = OrderedFloat<T>>>(iter: I) -> Self {
@@ -1386,7 +1402,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, rhs)).expect("Rem resulted in NaN")
+                $from_expr(<$inner>::pow(self.0, rhs)).expect("Pow resulted in NaN")
             }
         }
 
@@ -1394,7 +1410,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Rem resulted in NaN")
+                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Pow resulted in NaN")
             }
         }
 
@@ -1402,7 +1418,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, rhs)).expect("Rem resulted in NaN")
+                $from_expr(<$inner>::pow(self.0, rhs)).expect("Pow resulted in NaN")
             }
         }
 
@@ -1410,7 +1426,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Rem resulted in NaN")
+                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Pow resulted in NaN")
             }
         }
     };
@@ -1429,6 +1445,23 @@ impl_not_nan_pow! {f64, i32, NotNan::new}
 impl_not_nan_pow! {f32, f32, NotNan::new}
 impl_not_nan_pow! {f64, f32, NotNan::new}
 impl_not_nan_pow! {f64, f64, NotNan::new}
+
+// This also should panic on NaN
+macro_rules! impl_not_nan_self_pow {
+    ($base:ty, $exp:ty) => {
+        impl Pow<NotNan<$exp>> for NotNan<$base> {
+            type Output = NotNan<$base>;
+            #[inline]
+            fn pow(self, rhs: NotNan<$exp>) -> NotNan<$base> {
+                NotNan::new(self.0.pow(rhs.0)).expect("Pow resulted in NaN")
+            }
+        }
+    };
+}
+
+impl_not_nan_self_pow! {f32, f32}
+impl_not_nan_self_pow! {f64, f32}
+impl_not_nan_self_pow! {f64, f64}
 
 impl<T: Float> Neg for NotNan<T> {
     type Output = Self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,7 @@ impl_ordered_float_binop! {Rem, rem, RemAssign, rem_assign}
 
 macro_rules! impl_ordered_float_pow {
     ($inner:ty, $rhs:ty) => {
+        #[cfg(feature = "std")]
         impl Pow<$rhs> for OrderedFloat<$inner> {
             type Output = OrderedFloat<$inner>;
             #[inline]
@@ -356,6 +357,7 @@ macro_rules! impl_ordered_float_pow {
             }
         }
 
+        #[cfg(feature = "std")]
         impl<'a> Pow<&'a $rhs> for OrderedFloat<$inner> {
             type Output = OrderedFloat<$inner>;
             #[inline]
@@ -364,6 +366,7 @@ macro_rules! impl_ordered_float_pow {
             }
         }
 
+        #[cfg(feature = "std")]
         impl<'a> Pow<$rhs> for &'a OrderedFloat<$inner> {
             type Output = OrderedFloat<$inner>;
             #[inline]
@@ -372,6 +375,7 @@ macro_rules! impl_ordered_float_pow {
             }
         }
 
+        #[cfg(feature = "std")]
         impl<'a, 'b> Pow<&'a $rhs> for &'b OrderedFloat<$inner> {
             type Output = OrderedFloat<$inner>;
             #[inline]
@@ -398,10 +402,38 @@ impl_ordered_float_pow! {f64, f64}
 
 macro_rules! impl_ordered_float_self_pow {
     ($base:ty, $exp:ty) => {
+        #[cfg(feature = "std")]
         impl Pow<OrderedFloat<$exp>> for OrderedFloat<$base> {
             type Output = OrderedFloat<$base>;
             #[inline]
             fn pow(self, rhs: OrderedFloat<$exp>) -> OrderedFloat<$base> {
+                OrderedFloat(<$base>::pow(self.0, rhs.0))
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<'a> Pow<&'a OrderedFloat<$exp>> for OrderedFloat<$base> {
+            type Output = OrderedFloat<$base>;
+            #[inline]
+            fn pow(self, rhs: &'a OrderedFloat<$exp>) -> OrderedFloat<$base> {
+                OrderedFloat(<$base>::pow(self.0, rhs.0))
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<'a> Pow<OrderedFloat<$exp>> for &'a OrderedFloat<$base> {
+            type Output = OrderedFloat<$base>;
+            #[inline]
+            fn pow(self, rhs: OrderedFloat<$exp>) -> OrderedFloat<$base> {
+                OrderedFloat(<$base>::pow(self.0, rhs.0))
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<'a, 'b> Pow<&'a OrderedFloat<$exp>> for &'b OrderedFloat<$base> {
+            type Output = OrderedFloat<$base>;
+            #[inline]
+            fn pow(self, rhs: &'a OrderedFloat<$exp>) -> OrderedFloat<$base> {
                 OrderedFloat(<$base>::pow(self.0, rhs.0))
             }
         }
@@ -1386,6 +1418,7 @@ impl_not_nan_binop! {Rem, rem, RemAssign, rem_assign}
 // Will panic if NaN value is return from the operation
 macro_rules! impl_not_nan_pow {
     ($inner:ty, $rhs:ty) => {
+        #[cfg(feature = "std")]
         impl Pow<$rhs> for NotNan<$inner> {
             type Output = NotNan<$inner>;
             #[inline]
@@ -1394,6 +1427,7 @@ macro_rules! impl_not_nan_pow {
             }
         }
 
+        #[cfg(feature = "std")]
         impl<'a> Pow<&'a $rhs> for NotNan<$inner> {
             type Output = NotNan<$inner>;
             #[inline]
@@ -1402,6 +1436,7 @@ macro_rules! impl_not_nan_pow {
             }
         }
 
+        #[cfg(feature = "std")]
         impl<'a> Pow<$rhs> for &'a NotNan<$inner> {
             type Output = NotNan<$inner>;
             #[inline]
@@ -1410,6 +1445,7 @@ macro_rules! impl_not_nan_pow {
             }
         }
 
+        #[cfg(feature = "std")]
         impl<'a, 'b> Pow<&'a $rhs> for &'b NotNan<$inner> {
             type Output = NotNan<$inner>;
             #[inline]
@@ -1437,10 +1473,38 @@ impl_not_nan_pow! {f64, f64}
 // This also should panic on NaN
 macro_rules! impl_not_nan_self_pow {
     ($base:ty, $exp:ty) => {
+        #[cfg(feature = "std")]
         impl Pow<NotNan<$exp>> for NotNan<$base> {
             type Output = NotNan<$base>;
             #[inline]
             fn pow(self, rhs: NotNan<$exp>) -> NotNan<$base> {
+                NotNan::new(self.0.pow(rhs.0)).expect("Pow resulted in NaN")
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<'a> Pow<&'a NotNan<$exp>> for NotNan<$base> {
+            type Output = NotNan<$base>;
+            #[inline]
+            fn pow(self, rhs: &'a NotNan<$exp>) -> NotNan<$base> {
+                NotNan::new(self.0.pow(rhs.0)).expect("Pow resulted in NaN")
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<'a> Pow<NotNan<$exp>> for &'a NotNan<$base> {
+            type Output = NotNan<$base>;
+            #[inline]
+            fn pow(self, rhs: NotNan<$exp>) -> NotNan<$base> {
+                NotNan::new(self.0.pow(rhs.0)).expect("Pow resulted in NaN")
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<'a, 'b> Pow<&'a NotNan<$exp>> for &'b NotNan<$base> {
+            type Output = NotNan<$base>;
+            #[inline]
+            fn pow(self, rhs: &'a NotNan<$exp>) -> NotNan<$base> {
                 NotNan::new(self.0.pow(rhs.0)).expect("Pow resulted in NaN")
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,15 +347,12 @@ impl_ordered_float_binop! {Div, div, DivAssign, div_assign}
 impl_ordered_float_binop! {Rem, rem, RemAssign, rem_assign}
 
 macro_rules! impl_ordered_float_pow {
-    ($inner:ty, $rhs:ty, $from_expr:expr) => {
+    ($inner:ty, $rhs:ty) => {
         impl Pow<$rhs> for OrderedFloat<$inner> {
             type Output = OrderedFloat<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> OrderedFloat<$inner> {
-                match $from_expr(<$inner>::pow(self.0, rhs)) {
-                    Some(x) => x,
-                    None => OrderedFloat::nan(),
-                }
+                OrderedFloat(<$inner>::pow(self.0, rhs))
             }
         }
 
@@ -363,10 +360,7 @@ macro_rules! impl_ordered_float_pow {
             type Output = OrderedFloat<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> OrderedFloat<$inner> {
-                match $from_expr(<$inner>::pow(self.0, *rhs)) {
-                    Some(x) => x,
-                    None => OrderedFloat::nan(),
-                }
+                OrderedFloat(<$inner>::pow(self.0, *rhs))
             }
         }
 
@@ -374,10 +368,7 @@ macro_rules! impl_ordered_float_pow {
             type Output = OrderedFloat<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> OrderedFloat<$inner> {
-                match $from_expr(<$inner>::pow(self.0, rhs)) {
-                    Some(x) => x,
-                    None => OrderedFloat::nan(),
-                }
+                OrderedFloat(<$inner>::pow(self.0, rhs))
             }
         }
 
@@ -385,28 +376,25 @@ macro_rules! impl_ordered_float_pow {
             type Output = OrderedFloat<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> OrderedFloat<$inner> {
-                match $from_expr(<$inner>::pow(self.0, *rhs)) {
-                    Some(x) => x,
-                    None => OrderedFloat::nan(),
-                }
+                OrderedFloat(<$inner>::pow(self.0, *rhs))
             }
         }
     };
 }
 
-impl_ordered_float_pow! {f32, i8, OrderedFloat::from_f32}
-impl_ordered_float_pow! {f32, i16, OrderedFloat::from_f32}
-impl_ordered_float_pow! {f32, u8, OrderedFloat::from_f32}
-impl_ordered_float_pow! {f32, u16, OrderedFloat::from_f32}
-impl_ordered_float_pow! {f32, i32, OrderedFloat::from_f32}
-impl_ordered_float_pow! {f64, i8, OrderedFloat::from_f64}
-impl_ordered_float_pow! {f64, i16, OrderedFloat::from_f64}
-impl_ordered_float_pow! {f64, u8, OrderedFloat::from_f64}
-impl_ordered_float_pow! {f64, u16, OrderedFloat::from_f64}
-impl_ordered_float_pow! {f64, i32, OrderedFloat::from_f64}
-impl_ordered_float_pow! {f32, f32, OrderedFloat::from_f32}
-impl_ordered_float_pow! {f64, f32, OrderedFloat::from_f64}
-impl_ordered_float_pow! {f64, f64, OrderedFloat::from_f64}
+impl_ordered_float_pow! {f32, i8}
+impl_ordered_float_pow! {f32, i16}
+impl_ordered_float_pow! {f32, u8}
+impl_ordered_float_pow! {f32, u16}
+impl_ordered_float_pow! {f32, i32}
+impl_ordered_float_pow! {f64, i8}
+impl_ordered_float_pow! {f64, i16}
+impl_ordered_float_pow! {f64, u8}
+impl_ordered_float_pow! {f64, u16}
+impl_ordered_float_pow! {f64, i32}
+impl_ordered_float_pow! {f32, f32}
+impl_ordered_float_pow! {f64, f32}
+impl_ordered_float_pow! {f64, f64}
 
 macro_rules! impl_ordered_float_self_pow {
     ($base:ty, $exp:ty) => {
@@ -1397,12 +1385,12 @@ impl_not_nan_binop! {Rem, rem, RemAssign, rem_assign}
 
 // Will panic if NaN value is return from the operation
 macro_rules! impl_not_nan_pow {
-    ($inner:ty, $rhs:ty, $from_expr:expr) => {
+    ($inner:ty, $rhs:ty) => {
         impl Pow<$rhs> for NotNan<$inner> {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, rhs)).expect("Pow resulted in NaN")
+                NotNan::new(<$inner>::pow(self.0, rhs)).expect("Pow resulted in NaN")
             }
         }
 
@@ -1410,7 +1398,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Pow resulted in NaN")
+                NotNan::new(<$inner>::pow(self.0, *rhs)).expect("Pow resulted in NaN")
             }
         }
 
@@ -1418,7 +1406,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, rhs)).expect("Pow resulted in NaN")
+                NotNan::new(<$inner>::pow(self.0, rhs)).expect("Pow resulted in NaN")
             }
         }
 
@@ -1426,25 +1414,25 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> NotNan<$inner> {
-                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Pow resulted in NaN")
+                NotNan::new(<$inner>::pow(self.0, *rhs)).expect("Pow resulted in NaN")
             }
         }
     };
 }
 
-impl_not_nan_pow! {f32, i8, NotNan::new}
-impl_not_nan_pow! {f32, i16, NotNan::new}
-impl_not_nan_pow! {f32, u8, NotNan::new}
-impl_not_nan_pow! {f32, u16, NotNan::new}
-impl_not_nan_pow! {f32, i32, NotNan::new}
-impl_not_nan_pow! {f64, i8, NotNan::new}
-impl_not_nan_pow! {f64, i16, NotNan::new}
-impl_not_nan_pow! {f64, u8, NotNan::new}
-impl_not_nan_pow! {f64, u16, NotNan::new}
-impl_not_nan_pow! {f64, i32, NotNan::new}
-impl_not_nan_pow! {f32, f32, NotNan::new}
-impl_not_nan_pow! {f64, f32, NotNan::new}
-impl_not_nan_pow! {f64, f64, NotNan::new}
+impl_not_nan_pow! {f32, i8}
+impl_not_nan_pow! {f32, i16}
+impl_not_nan_pow! {f32, u8}
+impl_not_nan_pow! {f32, u16}
+impl_not_nan_pow! {f32, i32}
+impl_not_nan_pow! {f64, i8}
+impl_not_nan_pow! {f64, i16}
+impl_not_nan_pow! {f64, u8}
+impl_not_nan_pow! {f64, u16}
+impl_not_nan_pow! {f64, i32}
+impl_not_nan_pow! {f32, f32}
+impl_not_nan_pow! {f64, f32}
+impl_not_nan_pow! {f64, f64}
 
 // This also should panic on NaN
 macro_rules! impl_not_nan_self_pow {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,10 +396,17 @@ macro_rules! impl_ordered_float_pow {
 
 impl_ordered_float_pow! {f32, i8, OrderedFloat::from_f32}
 impl_ordered_float_pow! {f32, i16, OrderedFloat::from_f32}
+impl_ordered_float_pow! {f32, u8, OrderedFloat::from_f32}
+impl_ordered_float_pow! {f32, u16, OrderedFloat::from_f32}
 impl_ordered_float_pow! {f32, i32, OrderedFloat::from_f32}
 impl_ordered_float_pow! {f64, i8, OrderedFloat::from_f64}
 impl_ordered_float_pow! {f64, i16, OrderedFloat::from_f64}
+impl_ordered_float_pow! {f64, u8, OrderedFloat::from_f64}
+impl_ordered_float_pow! {f64, u16, OrderedFloat::from_f64}
 impl_ordered_float_pow! {f64, i32, OrderedFloat::from_f64}
+impl_ordered_float_pow! {f32, f32, OrderedFloat::from_f32}
+impl_ordered_float_pow! {f64, f32, OrderedFloat::from_f64}
+impl_ordered_float_pow! {f64, f64, OrderedFloat::from_f64}
 
 /// Adds a float directly.
 impl<T: Float + Sum> Sum for OrderedFloat<T> {
@@ -1379,7 +1386,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> NotNan<$inner> {
-                unsafe { $from_expr(<$inner>::pow(self.0, rhs)) }
+                $from_expr(<$inner>::pow(self.0, rhs)).expect("Rem resulted in NaN")
             }
         }
 
@@ -1387,7 +1394,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> NotNan<$inner> {
-                unsafe { $from_expr(<$inner>::pow(self.0, *rhs)) }
+                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Rem resulted in NaN")
             }
         }
 
@@ -1395,7 +1402,7 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: $rhs) -> NotNan<$inner> {
-                unsafe { $from_expr(<$inner>::pow(self.0, rhs)) }
+                $from_expr(<$inner>::pow(self.0, rhs)).expect("Rem resulted in NaN")
             }
         }
 
@@ -1403,18 +1410,25 @@ macro_rules! impl_not_nan_pow {
             type Output = NotNan<$inner>;
             #[inline]
             fn pow(self, rhs: &'a $rhs) -> NotNan<$inner> {
-                unsafe { $from_expr(<$inner>::pow(self.0, *rhs)) }
+                $from_expr(<$inner>::pow(self.0, *rhs)).expect("Rem resulted in NaN")
             }
         }
     };
 }
 
-impl_not_nan_pow! {f32, i8, NotNan::new_unchecked}
-impl_not_nan_pow! {f32, i16, NotNan::new_unchecked}
-impl_not_nan_pow! {f32, i32, NotNan::new_unchecked}
-impl_not_nan_pow! {f64, i8, NotNan::new_unchecked}
-impl_not_nan_pow! {f64, i16, NotNan::new_unchecked}
-impl_not_nan_pow! {f64, i32, NotNan::new_unchecked}
+impl_not_nan_pow! {f32, i8, NotNan::new}
+impl_not_nan_pow! {f32, i16, NotNan::new}
+impl_not_nan_pow! {f32, u8, NotNan::new}
+impl_not_nan_pow! {f32, u16, NotNan::new}
+impl_not_nan_pow! {f32, i32, NotNan::new}
+impl_not_nan_pow! {f64, i8, NotNan::new}
+impl_not_nan_pow! {f64, i16, NotNan::new}
+impl_not_nan_pow! {f64, u8, NotNan::new}
+impl_not_nan_pow! {f64, u16, NotNan::new}
+impl_not_nan_pow! {f64, i32, NotNan::new}
+impl_not_nan_pow! {f32, f32, NotNan::new}
+impl_not_nan_pow! {f64, f32, NotNan::new}
+impl_not_nan_pow! {f64, f64, NotNan::new}
 
 impl<T: Float> Neg for NotNan<T> {
     type Output = Self;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -746,6 +746,8 @@ fn float_consts_equal_inner() {
     test_float_const_methods!(NotNan<f64>);
     test_float_const_methods!(NotNan<f32>);
 }
+
+#[cfg(feature = "std")]
 macro_rules! test_pow_ord {
     ($type:ident < $inner:ident >) => {
         assert_eq!($type::<$inner>::from(3.0).pow(2i8), OrderedFloat(9.0));
@@ -757,6 +759,7 @@ macro_rules! test_pow_ord {
     };
 }
 
+#[cfg(feature = "std")]
 macro_rules! test_pow_nn {
     ($type:ident < $inner:ident >) => {
         assert_eq!(
@@ -786,6 +789,7 @@ macro_rules! test_pow_nn {
     };
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_pow_works() {
     assert_eq!(OrderedFloat(3.0).pow(OrderedFloat(2.0)), OrderedFloat(9.0));
@@ -805,6 +809,7 @@ fn test_pow_works() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 #[should_panic]
 fn test_pow_fails_on_nan() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -790,8 +790,13 @@ macro_rules! test_pow_nn {
 
 #[test]
 fn test_pow_works() {
+    assert_eq!(OrderedFloat(3.0).pow(OrderedFloat(2.0)), OrderedFloat(9.0));
     test_pow_ord!(OrderedFloat<f32>);
     test_pow_ord!(OrderedFloat<f64>);
+    assert_eq!(
+        NotNan::new(3.0).unwrap().pow(NotNan::new(2.0).unwrap()),
+        NotNan::new(9.0).unwrap()
+    );
     test_pow_nn!(NotNan<f32>);
     test_pow_nn!(NotNan<f64>);
     // Only f64 have Pow<f64> impl by default, so checking those seperate from macro

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,7 +7,9 @@ extern crate ordered_float;
 pub use num_traits::float::FloatCore as Float;
 #[cfg(feature = "std")]
 pub use num_traits::Float;
-pub use num_traits::{Bounded, FloatConst, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+pub use num_traits::{
+    Bounded, FloatConst, FromPrimitive, Num, One, Pow, Signed, ToPrimitive, Zero,
+};
 pub use ordered_float::*;
 
 pub use std::cmp::Ordering::*;
@@ -745,6 +747,67 @@ fn float_consts_equal_inner() {
     test_float_const_methods!(OrderedFloat<f32>);
     test_float_const_methods!(NotNan<f64>);
     test_float_const_methods!(NotNan<f32>);
+}
+macro_rules! test_pow_ord {
+    ($type:ident < $inner:ident >) => {
+        assert_eq!($type::<$inner>::from(3.0).pow(2i8), OrderedFloat(9.0));
+        assert_eq!($type::<$inner>::from(3.0).pow(2i16), OrderedFloat(9.0));
+        assert_eq!($type::<$inner>::from(3.0).pow(2i32), OrderedFloat(9.0));
+        assert_eq!($type::<$inner>::from(3.0).pow(2u8), OrderedFloat(9.0));
+        assert_eq!($type::<$inner>::from(3.0).pow(2u16), OrderedFloat(9.0));
+        assert_eq!($type::<$inner>::from(3.0).pow(2f32), OrderedFloat(9.0));
+    };
+}
+
+macro_rules! test_pow_nn {
+    ($type:ident < $inner:ident >) => {
+        assert_eq!(
+            $type::<$inner>::new(3.0).unwrap().pow(2i8),
+            NotNan::new(9.0).unwrap()
+        );
+        assert_eq!(
+            $type::<$inner>::new(3.0).unwrap().pow(2u8),
+            NotNan::new(9.0).unwrap()
+        );
+        assert_eq!(
+            $type::<$inner>::new(3.0).unwrap().pow(2i16),
+            NotNan::new(9.0).unwrap()
+        );
+        assert_eq!(
+            $type::<$inner>::new(3.0).unwrap().pow(2u16),
+            NotNan::new(9.0).unwrap()
+        );
+        assert_eq!(
+            $type::<$inner>::new(3.0).unwrap().pow(2i32),
+            NotNan::new(9.0).unwrap()
+        );
+        assert_eq!(
+            $type::<$inner>::new(3.0).unwrap().pow(2f32),
+            NotNan::new(9.0).unwrap()
+        );
+    };
+}
+
+#[test]
+fn test_pow_works() {
+    test_pow_ord!(OrderedFloat<f32>);
+    test_pow_ord!(OrderedFloat<f64>);
+    test_pow_nn!(NotNan<f32>);
+    test_pow_nn!(NotNan<f64>);
+    // Only f64 have Pow<f64> impl by default, so checking those seperate from macro
+    assert_eq!(OrderedFloat::<f64>::from(3.0).pow(2f64), OrderedFloat(9.0));
+    assert_eq!(
+        NotNan::<f64>::new(3.0).unwrap().pow(2f64),
+        NotNan::new(9.0).unwrap()
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_pow_fails_on_nan() {
+    let a = not_nan(-1.0);
+    let b = f32::NAN;
+    a.pow(b);
 }
 
 #[cfg(feature = "arbitrary")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,11 +5,9 @@ extern crate ordered_float;
 
 #[cfg(not(feature = "std"))]
 pub use num_traits::float::FloatCore as Float;
+pub use num_traits::{Bounded, FloatConst, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
 #[cfg(feature = "std")]
-pub use num_traits::Float;
-pub use num_traits::{
-    Bounded, FloatConst, FromPrimitive, Num, One, Pow, Signed, ToPrimitive, Zero,
-};
+pub use num_traits::{Float, Pow};
 pub use ordered_float::*;
 
 pub use std::cmp::Ordering::*;


### PR DESCRIPTION
Issue #118 asked for implementation of the Pow trait for OrderedFloat and NotNan. I have implemented the Pow trait for both in 2 ways. 

1. This implements the trait for exponents that are primitive types (i8, i16, i32, u8, u16, f32, f64) that num_traits does, https://docs.rs/num-traits/latest/num_traits/pow/trait.Pow.html, for the f32 and f64 types respectfully. 
2. This implements the trait for exponents and bases that both either OrderedFloat or NotNan. 

I have not implemented any mixing of OrderedFloat and NotNan, as the proper return type is not obvious. I have also not implemented Pow for the base being primitive (i8, i16, i32, u8, u16, f32, f64) with an exponent of either OrderedFloat or NotNan, as again the return type for this operation is not clear to me.

I also added a few tests to ensure things are working as expected. 