### PR TITLE
Make `impl_rand` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use num_traits::{
 pub use num_traits::{Float, Pow};
 
 #[cfg(feature = "rand")]
-pub use impl_rand::{UniformNotNan, UniformOrdered};
+pub use impl_rand::UniformOrdered;
 
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
@@ -2256,6 +2256,7 @@ mod impl_rand {
         type Sampler = UniformNotNan<f64>;
     }
 
+    /// A sampler for a uniform distribution
     #[derive(Clone, Copy, Debug, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct UniformOrdered<T>(UniformFloat<T>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2212,7 +2212,7 @@ mod impl_schemars {
 }
 
 #[cfg(feature = "rand")]
-mod impl_rand {
+pub mod impl_rand {
     use super::{NotNan, OrderedFloat};
     use rand::distributions::uniform::*;
     use rand::distributions::{Distribution, Open01, OpenClosed01, Standard};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ use num_traits::{
 #[cfg(feature = "std")]
 pub use num_traits::{Float, Pow};
 
+#[cfg(feature = "rand")]
+pub use impl_rand::{UniformNotNan, UniformOrdered};
+
 // masks for the parts of the IEEE 754 float
 const SIGN_MASK: u64 = 0x8000000000000000u64;
 const EXP_MASK: u64 = 0x7ff0000000000000u64;
@@ -2212,7 +2215,7 @@ mod impl_schemars {
 }
 
 #[cfg(feature = "rand")]
-pub mod impl_rand {
+mod impl_rand {
     use super::{NotNan, OrderedFloat};
     use rand::distributions::uniform::*;
     use rand::distributions::{Distribution, Open01, OpenClosed01, Standard};


### PR DESCRIPTION
I'd like to be able to access `UniformOrdered` from the `impl_rand` module. I'm not sure why the struct is not exposed by default, but this PR allows for that. 
I can imagine why the `impl_rand` module is not public, but I wonder what the proper way would be for this crate to expose `UniformOrdered`.
Any pointer are appreciated