### PR TITLE
Implement `rkyv` endianess

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -67,10 +67,10 @@ fn ordered_f32_compare_nan_op() {
     assert!(f32_nan >= OrderedFloat(-100000.0f32));
     assert!(OrderedFloat(-100.0f32) < f32_nan);
     assert!(OrderedFloat(-100.0f32) <= f32_nan);
-    assert!(f32_nan > OrderedFloat(Float::infinity()));
-    assert!(f32_nan >= OrderedFloat(Float::infinity()));
-    assert!(f32_nan > OrderedFloat(Float::neg_infinity()));
-    assert!(f32_nan >= OrderedFloat(Float::neg_infinity()));
+    assert!(f32_nan > OrderedFloat(f32::infinity()));
+    assert!(f32_nan >= OrderedFloat(f32::infinity()));
+    assert!(f32_nan > OrderedFloat(f32::neg_infinity()));
+    assert!(f32_nan >= OrderedFloat(f32::neg_infinity()));
 }
 
 #[test]
@@ -198,10 +198,10 @@ fn ordered_f64_compare_nan_op() {
     assert!(f64_nan >= OrderedFloat(-100000.0));
     assert!(OrderedFloat(-100.0) < f64_nan);
     assert!(OrderedFloat(-100.0) <= f64_nan);
-    assert!(f64_nan > OrderedFloat(Float::infinity()));
-    assert!(f64_nan >= OrderedFloat(Float::infinity()));
-    assert!(f64_nan > OrderedFloat(Float::neg_infinity()));
-    assert!(f64_nan >= OrderedFloat(Float::neg_infinity()));
+    assert!(f64_nan > OrderedFloat(f64::infinity()));
+    assert!(f64_nan >= OrderedFloat(f64::infinity()));
+    assert!(f64_nan > OrderedFloat(f64::neg_infinity()));
+    assert!(f64_nan >= OrderedFloat(f64::neg_infinity()));
 }
 
 #[test]


### PR DESCRIPTION
I've notice, that you are using `NotNan<T>`/`OrderedFloat<T>` as Archived values. This leads to compilation failure if rkyv used with `archive_le` or `archive_be` features:
```
cargo t -F rkyv/archive_le
```
```
error[E0308]: mismatched types
    --> src/lib.rs:2013:46
     |
2013 |         let deser_float: OrderedFloat<f64> = archived_value.deserialize(&mut deserializer).unwrap();
     |                          -----------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `OrderedFloat<f64>`, found `With<_, _>`
     |                          |
     |                          expected due to this
     |
     = note: expected struct `OrderedFloat<f64>`
                found struct `With<_, _>`
```

My PR implements `rkyv::Archive` properly considering this features