### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,4 +78,4 @@ jobs:
           args: --features ${{ env.all_features }}
 
 env:
-  all_features: "bytemuck,rand,randtest,serde,schemars,proptest,rkyv,rkyv_ck,speedy"
+  all_features: "arbitrary,bytemuck,rand,randtest,serde,schemars,proptest,rkyv,rkyv_ck,speedy"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1807,6 +1807,7 @@ impl<T: Float> NumCast for NotNan<T> {
 macro_rules! impl_float_const_method {
     ($wrapper:expr, $method:ident) => {
         #[allow(non_snake_case)]
+        #[allow(clippy::redundant_closure_call)]
         fn $method() -> Self {
             $wrapper(T::$method())
         }


### PR DESCRIPTION
* Add missing `arbitrary` to list of features in CI.
* Allow `clippy::redundant_closure_call` false positive.