### PR TITLE
Remove implicit panics in NotNan<T> x T operators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1227,10 +1227,7 @@ impl<T: FloatCore + Num> Num for OrderedFloat<T> {
 /// ```
 /// use ordered_float::NotNan;
 ///
-/// let mut v = [
-///     NotNan::new(2.0).unwrap(),
-///     NotNan::new(1.0).unwrap(),
-/// ];
+/// let mut v = [NotNan::new(2.0).unwrap(), NotNan::new(1.0).unwrap()];
 /// v.sort();
 /// assert_eq!(v, [1.0, 2.0]);
 /// ```
@@ -1270,7 +1267,6 @@ impl<T: FloatCore + Num> Num for OrderedFloat<T> {
 /// [transmute](core::mem::transmute) or pointer casts to convert between any type `T` and
 /// `NotNan<T>`, as long as this does not create a NaN value.
 /// However, consider using [`bytemuck`] as a safe alternative if possible.
-///
 #[cfg_attr(
     not(feature = "bytemuck"),
     doc = "[`bytemuck`]: https://docs.rs/bytemuck/1/"
@@ -1384,9 +1380,10 @@ impl NotNan<f64> {
     /// Note: For the reverse conversion (from `NotNan<f32>` to `NotNan<f64>`), you can use
     /// `.into()`.
     pub fn as_f32(self) -> NotNan<f32> {
-        // This is not destroying invariants, as it is a pure rounding operation. The only two special
-        // cases are where f32 would be overflowing, then the operation yields Infinity, or where
-        // the input is already NaN, in which case the invariant is already broken elsewhere.
+        // This is not destroying invariants, as it is a pure rounding operation. The only two
+        // special cases are where f32 would be overflowing, then the operation yields
+        // Infinity, or where the input is already NaN, in which case the invariant is
+        // already broken elsewhere.
         NotNan(self.0 as f32)
     }
 }
@@ -1473,14 +1470,14 @@ impl<T: FloatCore> PartialEq<T> for NotNan<T> {
 /// Adds a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: FloatCore> Add<T> for NotNan<T> {
+/*impl<T: FloatCore> Add<T> for NotNan<T> {
     type Output = Self;
 
     #[inline]
     fn add(self, other: T) -> Self {
         NotNan::new(self.0 + other).expect("Addition resulted in NaN")
     }
-}
+}*/
 
 /// Adds a float directly.
 ///
@@ -1501,26 +1498,26 @@ impl<'a, T: FloatCore + Sum + 'a> Sum<&'a NotNan<T>> for NotNan<T> {
 /// Subtracts a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: FloatCore> Sub<T> for NotNan<T> {
+/*impl<T: FloatCore> Sub<T> for NotNan<T> {
     type Output = Self;
 
     #[inline]
     fn sub(self, other: T) -> Self {
         NotNan::new(self.0 - other).expect("Subtraction resulted in NaN")
     }
-}
+}*/
 
 /// Multiplies a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
-impl<T: FloatCore> Mul<T> for NotNan<T> {
+/*impl<T: FloatCore> Mul<T> for NotNan<T> {
     type Output = Self;
 
     #[inline]
     fn mul(self, other: T) -> Self {
         NotNan::new(self.0 * other).expect("Multiplication resulted in NaN")
     }
-}
+}*/
 
 impl<T: FloatCore + Product> Product for NotNan<T> {
     fn product<I: Iterator<Item = NotNan<T>>>(iter: I) -> Self {
@@ -1535,6 +1532,7 @@ impl<'a, T: FloatCore + Product + 'a> Product<&'a NotNan<T>> for NotNan<T> {
     }
 }
 
+/*
 /// Divides a float directly.
 ///
 /// Panics if the provided value is NaN or the computation results in NaN
@@ -1557,7 +1555,7 @@ impl<T: FloatCore> Rem<T> for NotNan<T> {
     fn rem(self, other: T) -> Self {
         NotNan::new(self.0 % other).expect("Rem resulted in NaN")
     }
-}
+}*/
 
 macro_rules! impl_not_nan_binop {
     ($imp:ident, $method:ident, $assign_imp:ident, $assign_method:ident) => {
@@ -1566,25 +1564,26 @@ macro_rules! impl_not_nan_binop {
 
             #[inline]
             fn $method(self, other: Self) -> Self {
-                self.$method(other.0)
+                NotNan::new(self.0.$method(other.0))
+                    .expect("Operation on two NotNan resulted in NaN")
             }
         }
 
-        impl<T: FloatCore> $imp<&T> for NotNan<T> {
+        /*impl<T: FloatCore> $imp<&T> for NotNan<T> {
             type Output = NotNan<T>;
 
             #[inline]
             fn $method(self, other: &T) -> Self::Output {
                 self.$method(*other)
             }
-        }
+        }*/
 
         impl<T: FloatCore> $imp<&Self> for NotNan<T> {
             type Output = NotNan<T>;
 
             #[inline]
             fn $method(self, other: &Self) -> Self::Output {
-                self.$method(other.0)
+                self.$method(*other)
             }
         }
 
@@ -1593,7 +1592,7 @@ macro_rules! impl_not_nan_binop {
 
             #[inline]
             fn $method(self, other: Self) -> Self::Output {
-                (*self).$method(other.0)
+                (*self).$method(*other)
             }
         }
 
@@ -1602,11 +1601,11 @@ macro_rules! impl_not_nan_binop {
 
             #[inline]
             fn $method(self, other: NotNan<T>) -> Self::Output {
-                (*self).$method(other.0)
+                (*self).$method(other)
             }
         }
 
-        impl<T: FloatCore> $imp<T> for &NotNan<T> {
+        /*impl<T: FloatCore> $imp<T> for &NotNan<T> {
             type Output = NotNan<T>;
 
             #[inline]
@@ -1636,19 +1635,19 @@ macro_rules! impl_not_nan_binop {
             fn $assign_method(&mut self, other: &T) {
                 *self = (*self).$method(*other);
             }
-        }
+        }*/
 
         impl<T: FloatCore + $assign_imp> $assign_imp for NotNan<T> {
             #[inline]
             fn $assign_method(&mut self, other: Self) {
-                (*self).$assign_method(other.0);
+                *self = (*self).$method(other);
             }
         }
 
         impl<T: FloatCore + $assign_imp> $assign_imp<&Self> for NotNan<T> {
             #[inline]
             fn $assign_method(&mut self, other: &Self) {
-                (*self).$assign_method(other.0);
+                *self = (*self).$method(*other);
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1469,15 +1469,15 @@ impl<T: FloatCore> PartialEq<T> for NotNan<T> {
 
 /// Adds a float directly.
 ///
-/// Panics if the provided value is NaN or the computation results in NaN
-/*impl<T: FloatCore> Add<T> for NotNan<T> {
-    type Output = Self;
+/// This returns a `T` and not a `NotNan<T>` because if the added value is NaN, this will be NaN
+impl<T: FloatCore> Add<T> for NotNan<T> {
+    type Output = T;
 
     #[inline]
-    fn add(self, other: T) -> Self {
-        NotNan::new(self.0 + other).expect("Addition resulted in NaN")
+    fn add(self, other: T) -> Self::Output {
+        self.0 + other
     }
-}*/
+}
 
 /// Adds a float directly.
 ///
@@ -1497,27 +1497,29 @@ impl<'a, T: FloatCore + Sum + 'a> Sum<&'a NotNan<T>> for NotNan<T> {
 
 /// Subtracts a float directly.
 ///
-/// Panics if the provided value is NaN or the computation results in NaN
-/*impl<T: FloatCore> Sub<T> for NotNan<T> {
-    type Output = Self;
+/// This returns a `T` and not a `NotNan<T>` because if the substracted value is NaN, this will be
+/// NaN
+impl<T: FloatCore> Sub<T> for NotNan<T> {
+    type Output = T;
 
     #[inline]
-    fn sub(self, other: T) -> Self {
-        NotNan::new(self.0 - other).expect("Subtraction resulted in NaN")
+    fn sub(self, other: T) -> Self::Output {
+        self.0 - other
     }
-}*/
+}
 
 /// Multiplies a float directly.
 ///
-/// Panics if the provided value is NaN or the computation results in NaN
-/*impl<T: FloatCore> Mul<T> for NotNan<T> {
-    type Output = Self;
+/// This returns a `T` and not a `NotNan<T>` because if the multiplied value is NaN, this will be
+/// NaN
+impl<T: FloatCore> Mul<T> for NotNan<T> {
+    type Output = T;
 
     #[inline]
-    fn mul(self, other: T) -> Self {
-        NotNan::new(self.0 * other).expect("Multiplication resulted in NaN")
+    fn mul(self, other: T) -> Self::Output {
+        self.0 * other
     }
-}*/
+}
 
 impl<T: FloatCore + Product> Product for NotNan<T> {
     fn product<I: Iterator<Item = NotNan<T>>>(iter: I) -> Self {
@@ -1532,30 +1534,30 @@ impl<'a, T: FloatCore + Product + 'a> Product<&'a NotNan<T>> for NotNan<T> {
     }
 }
 
-/*
 /// Divides a float directly.
 ///
-/// Panics if the provided value is NaN or the computation results in NaN
+/// This returns a `T` and not a `NotNan<T>` because if the divided-by value is NaN, this will be
+/// NaN
 impl<T: FloatCore> Div<T> for NotNan<T> {
-    type Output = Self;
+    type Output = T;
 
     #[inline]
-    fn div(self, other: T) -> Self {
-        NotNan::new(self.0 / other).expect("Division resulted in NaN")
+    fn div(self, other: T) -> Self::Output {
+        self.0 / other
     }
 }
 
 /// Calculates `%` with a float directly.
 ///
-/// Panics if the provided value is NaN or the computation results in NaN
+/// This returns a `T` and not a `NotNan<T>` because if the RHS is NaN, this will be NaN
 impl<T: FloatCore> Rem<T> for NotNan<T> {
-    type Output = Self;
+    type Output = T;
 
     #[inline]
-    fn rem(self, other: T) -> Self {
-        NotNan::new(self.0 % other).expect("Rem resulted in NaN")
+    fn rem(self, other: T) -> Self::Output {
+        self.0 % other
     }
-}*/
+}
 
 macro_rules! impl_not_nan_binop {
     ($imp:ident, $method:ident, $assign_imp:ident, $assign_method:ident) => {
@@ -1569,14 +1571,14 @@ macro_rules! impl_not_nan_binop {
             }
         }
 
-        /*impl<T: FloatCore> $imp<&T> for NotNan<T> {
-            type Output = NotNan<T>;
+        impl<T: FloatCore> $imp<&T> for NotNan<T> {
+            type Output = T;
 
             #[inline]
             fn $method(self, other: &T) -> Self::Output {
                 self.$method(*other)
             }
-        }*/
+        }
 
         impl<T: FloatCore> $imp<&Self> for NotNan<T> {
             type Output = NotNan<T>;
@@ -1605,8 +1607,8 @@ macro_rules! impl_not_nan_binop {
             }
         }
 
-        /*impl<T: FloatCore> $imp<T> for &NotNan<T> {
-            type Output = NotNan<T>;
+        impl<T: FloatCore> $imp<T> for &NotNan<T> {
+            type Output = T;
 
             #[inline]
             fn $method(self, other: T) -> Self::Output {
@@ -1615,27 +1617,13 @@ macro_rules! impl_not_nan_binop {
         }
 
         impl<T: FloatCore> $imp<&T> for &NotNan<T> {
-            type Output = NotNan<T>;
+            type Output = T;
 
             #[inline]
             fn $method(self, other: &T) -> Self::Output {
                 (*self).$method(*other)
             }
         }
-
-        impl<T: FloatCore + $assign_imp> $assign_imp<T> for NotNan<T> {
-            #[inline]
-            fn $assign_method(&mut self, other: T) {
-                *self = (*self).$method(other);
-            }
-        }
-
-        impl<T: FloatCore + $assign_imp> $assign_imp<&T> for NotNan<T> {
-            #[inline]
-            fn $assign_method(&mut self, other: &T) {
-                *self = (*self).$method(*other);
-            }
-        }*/
 
         impl<T: FloatCore + $assign_imp> $assign_imp for NotNan<T> {
             #[inline]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -257,22 +257,22 @@ fn not_nan32_fail_when_constructing_with_nan() {
 #[test]
 fn not_nan32_calculate_correctly() {
     assert_eq!(*(not_nan(5.0f32) + not_nan(4.0f32)), 5.0f32 + 4.0f32);
-    assert_eq!(*(not_nan(5.0f32) + 4.0f32), 5.0f32 + 4.0f32);
+    assert_eq!(not_nan(5.0f32) + 4.0f32, 5.0f32 + 4.0f32);
     assert_eq!(*(not_nan(5.0f32) - not_nan(4.0f32)), 5.0f32 - 4.0f32);
-    assert_eq!(*(not_nan(5.0f32) - 4.0f32), 5.0f32 - 4.0f32);
+    assert_eq!(not_nan(5.0f32) - 4.0f32, 5.0f32 - 4.0f32);
     assert_eq!(*(not_nan(5.0f32) * not_nan(4.0f32)), 5.0f32 * 4.0f32);
-    assert_eq!(*(not_nan(5.0f32) * 4.0f32), 5.0f32 * 4.0f32);
+    assert_eq!(not_nan(5.0f32) * 4.0f32, 5.0f32 * 4.0f32);
     assert_eq!(*(not_nan(8.0f32) / not_nan(4.0f32)), 8.0f32 / 4.0f32);
-    assert_eq!(*(not_nan(8.0f32) / 4.0f32), 8.0f32 / 4.0f32);
+    assert_eq!(not_nan(8.0f32) / 4.0f32, 8.0f32 / 4.0f32);
     assert_eq!(*(not_nan(8.0f32) % not_nan(4.0f32)), 8.0f32 % 4.0f32);
-    assert_eq!(*(not_nan(8.0f32) % 4.0f32), 8.0f32 % 4.0f32);
+    assert_eq!(not_nan(8.0f32) % 4.0f32, 8.0f32 % 4.0f32);
     assert_eq!(*(-not_nan(1.0f32)), -1.0f32);
 
-    assert!(panic::catch_unwind(|| not_nan(0.0f32) + f32::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f32) - f32::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f32) * f32::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f32) / f32::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f32) % f32::NAN).is_err());
+    assert!(f32::is_nan(not_nan(0.0f32) + f32::NAN));
+    assert!(f32::is_nan(not_nan(0.0f32) - f32::NAN));
+    assert!(f32::is_nan(not_nan(0.0f32) * f32::NAN));
+    assert!(f32::is_nan(not_nan(0.0f32) / f32::NAN));
+    assert!(f32::is_nan(not_nan(0.0f32) % f32::NAN));
 
     let mut number = not_nan(5.0f32);
     number += not_nan(4.0f32);
@@ -285,44 +285,6 @@ fn not_nan32_calculate_correctly() {
     assert_eq!(*number, 5.0f32);
     number %= not_nan(4.0f32);
     assert_eq!(*number, 1.0f32);
-
-    number = not_nan(5.0f32);
-    number += 4.0f32;
-    assert_eq!(*number, 9.0f32);
-    number -= 4.0f32;
-    assert_eq!(*number, 5.0f32);
-    number *= 4.0f32;
-    assert_eq!(*number, 20.0f32);
-    number /= 4.0f32;
-    assert_eq!(*number, 5.0f32);
-    number %= 4.0f32;
-    assert_eq!(*number, 1.0f32);
-
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f32);
-        tmp += f32::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f32);
-        tmp -= f32::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f32);
-        tmp *= f32::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f32);
-        tmp /= f32::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f32);
-        tmp %= f32::NAN;
-    })
-    .is_err());
 }
 
 #[test]
@@ -341,22 +303,22 @@ fn not_nan64_fail_when_constructing_with_nan() {
 #[test]
 fn not_nan64_calculate_correctly() {
     assert_eq!(*(not_nan(5.0f64) + not_nan(4.0f64)), 5.0f64 + 4.0f64);
-    assert_eq!(*(not_nan(5.0f64) + 4.0f64), 5.0f64 + 4.0f64);
+    assert_eq!(not_nan(5.0f64) + 4.0f64, 5.0f64 + 4.0f64);
     assert_eq!(*(not_nan(5.0f64) - not_nan(4.0f64)), 5.0f64 - 4.0f64);
-    assert_eq!(*(not_nan(5.0f64) - 4.0f64), 5.0f64 - 4.0f64);
+    assert_eq!(not_nan(5.0f64) - 4.0f64, 5.0f64 - 4.0f64);
     assert_eq!(*(not_nan(5.0f64) * not_nan(4.0f64)), 5.0f64 * 4.0f64);
-    assert_eq!(*(not_nan(5.0f64) * 4.0f64), 5.0f64 * 4.0f64);
+    assert_eq!(not_nan(5.0f64) * 4.0f64, 5.0f64 * 4.0f64);
     assert_eq!(*(not_nan(8.0f64) / not_nan(4.0f64)), 8.0f64 / 4.0f64);
-    assert_eq!(*(not_nan(8.0f64) / 4.0f64), 8.0f64 / 4.0f64);
+    assert_eq!(not_nan(8.0f64) / 4.0f64, 8.0f64 / 4.0f64);
     assert_eq!(*(not_nan(8.0f64) % not_nan(4.0f64)), 8.0f64 % 4.0f64);
-    assert_eq!(*(not_nan(8.0f64) % 4.0f64), 8.0f64 % 4.0f64);
+    assert_eq!(not_nan(8.0f64) % 4.0f64, 8.0f64 % 4.0f64);
     assert_eq!(*(-not_nan(1.0f64)), -1.0f64);
 
-    assert!(panic::catch_unwind(|| not_nan(0.0f64) + f64::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f64) - f64::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f64) * f64::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f64) / f64::NAN).is_err());
-    assert!(panic::catch_unwind(|| not_nan(0.0f64) % f64::NAN).is_err());
+    assert!(f64::is_nan(not_nan(0.0f64) + f64::NAN));
+    assert!(f64::is_nan(not_nan(0.0f64) - f64::NAN));
+    assert!(f64::is_nan(not_nan(0.0f64) * f64::NAN));
+    assert!(f64::is_nan(not_nan(0.0f64) / f64::NAN));
+    assert!(f64::is_nan(not_nan(0.0f64) % f64::NAN));
 
     let mut number = not_nan(5.0f64);
     number += not_nan(4.0f64);
@@ -369,44 +331,6 @@ fn not_nan64_calculate_correctly() {
     assert_eq!(*number, 5.0f64);
     number %= not_nan(4.0f64);
     assert_eq!(*number, 1.0f64);
-
-    number = not_nan(5.0f64);
-    number += 4.0f64;
-    assert_eq!(*number, 9.0f64);
-    number -= 4.0f64;
-    assert_eq!(*number, 5.0f64);
-    number *= 4.0f64;
-    assert_eq!(*number, 20.0f64);
-    number /= 4.0f64;
-    assert_eq!(*number, 5.0f64);
-    number %= 4.0f64;
-    assert_eq!(*number, 1.0f64);
-
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f64);
-        tmp += f64::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f64);
-        tmp -= f64::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f64);
-        tmp *= f64::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f64);
-        tmp /= f64::NAN;
-    })
-    .is_err());
-    assert!(panic::catch_unwind(|| {
-        let mut tmp = not_nan(0.0f64);
-        tmp %= f64::NAN;
-    })
-    .is_err());
 }
 
 #[test]
@@ -578,7 +502,7 @@ fn hash_is_good_for_fractional_numbers() {
 fn test_add_fails_on_nan() {
     let a = not_nan(f32::INFINITY);
     let b = not_nan(f32::NEG_INFINITY);
-    let _c = a + b;
+    let _c: NotNan<f32> = a + b;
 }
 
 #[test]
@@ -586,7 +510,7 @@ fn test_add_fails_on_nan() {
 fn test_add_fails_on_nan_ref() {
     let a = not_nan(f32::INFINITY);
     let b = not_nan(f32::NEG_INFINITY);
-    let _c = a + &b;
+    let _c: NotNan<f32> = a + &b;
 }
 
 #[test]
@@ -594,31 +518,7 @@ fn test_add_fails_on_nan_ref() {
 fn test_add_fails_on_nan_ref_ref() {
     let a = not_nan(f32::INFINITY);
     let b = not_nan(f32::NEG_INFINITY);
-    let _c = &a + &b;
-}
-
-#[test]
-#[should_panic]
-fn test_add_fails_on_nan_t_ref() {
-    let a = not_nan(f32::INFINITY);
-    let b = f32::NEG_INFINITY;
-    let _c = a + &b;
-}
-
-#[test]
-#[should_panic]
-fn test_add_fails_on_nan_ref_t_ref() {
-    let a = not_nan(f32::INFINITY);
-    let b = f32::NEG_INFINITY;
-    let _c = &a + &b;
-}
-
-#[test]
-#[should_panic]
-fn test_add_fails_on_nan_ref_t() {
-    let a = not_nan(f32::INFINITY);
-    let b = f32::NEG_INFINITY;
-    let _c = &a + b;
+    let _c: NotNan<f32> = &a + &b;
 }
 
 #[test]
@@ -627,22 +527,6 @@ fn test_add_assign_fails_on_nan_ref() {
     let mut a = not_nan(f32::INFINITY);
     let b = not_nan(f32::NEG_INFINITY);
     a += &b;
-}
-
-#[test]
-#[should_panic]
-fn test_add_assign_fails_on_nan_t_ref() {
-    let mut a = not_nan(f32::INFINITY);
-    let b = f32::NEG_INFINITY;
-    a += &b;
-}
-
-#[test]
-#[should_panic]
-fn test_add_assign_fails_on_nan_t() {
-    let mut a = not_nan(f32::INFINITY);
-    let b = f32::NEG_INFINITY;
-    a += b;
 }
 
 #[test]
@@ -729,11 +613,11 @@ fn not_nan_panic_safety() {
         num
     };
 
-    assert!(!catch_op(not_nan(f32::INFINITY), |a| *a += f32::NEG_INFINITY).is_nan());
-    assert!(!catch_op(not_nan(f32::INFINITY), |a| *a -= f32::INFINITY).is_nan());
-    assert!(!catch_op(not_nan(0.0), |a| *a *= f32::INFINITY).is_nan());
-    assert!(!catch_op(not_nan(0.0), |a| *a /= 0.0).is_nan());
-    assert!(!catch_op(not_nan(0.0), |a| *a %= 0.0).is_nan());
+    assert!(!catch_op(not_nan(f32::INFINITY), |a| *a += not_nan(f32::NEG_INFINITY)).is_nan());
+    assert!(!catch_op(not_nan(f32::INFINITY), |a| *a -= not_nan(f32::INFINITY)).is_nan());
+    assert!(!catch_op(not_nan(0.0), |a| *a *= not_nan(f32::INFINITY)).is_nan());
+    assert!(!catch_op(not_nan(0.0), |a| *a /= not_nan(0.0)).is_nan());
+    assert!(!catch_op(not_nan(0.0), |a| *a %= not_nan(0.0)).is_nan());
 }
 
 #[test]


### PR DESCRIPTION
Resolves #166 as discussed there.

Tests that disappear are those that relate to `not_nan += maybe_nan` panicking which now doesn't compile.

Apologies for the small amount of extra auto-formatting, please let me know if that is an issue and I'll remove it.
