### PR TITLE
bump schemars to 1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,8 @@ dependencies = [
  "rand 0.8.5",
  "rkyv 0.7.46",
  "rkyv 0.8.15",
- "schemars",
+ "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_test",
  "speedy",
@@ -621,6 +622,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,7 +749,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -738,6 +772,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand       = { version = "0.8.3", optional = true, default-features = false }
 rkyv       = { version = "0.7.41", optional = true, default-features = false, features = ["rend"] }
 rkyv_08    = { version = "0.8", optional = true, default-features = false, package = "rkyv" }
 schemars   = { version = "0.8.8", optional = true }
+schemars1   = { package = "schemars", version = "1.2", optional = true }
 serde      = { version = "1.0", optional = true, default-features = false }
 speedy     = { version = "0.8.3", optional = true, default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2690,6 +2690,98 @@ mod impl_schemars {
     }
 }
 
+#[cfg(all(feature = "std", feature = "schemars1"))]
+mod impl_schemars1 {
+    extern crate schemars1 as schemars;
+    use self::schemars::generate::SchemaGenerator;
+    use self::schemars::Schema;
+    use super::{NotNan, OrderedFloat};
+
+    macro_rules! primitive_float_impl {
+        ($type:ty, $schema_name:literal) => {
+            impl schemars::JsonSchema for $type {
+                fn inline_schema() -> bool {
+                    true
+                }
+
+                fn schema_id() -> std::borrow::Cow<'static, str> {
+                    concat!(module_path!(), "::", core::stringify!($type)).into()
+                }
+
+                fn schema_name() -> std::borrow::Cow<'static, str> {
+                    std::borrow::Cow::from($schema_name)
+                }
+
+                fn json_schema(_: &mut SchemaGenerator) -> Schema {
+                    schemars1::json_schema!({
+                        "type": "number",
+                        "title": $schema_name,
+                        "format": $schema_name,
+                    })
+                }
+            }
+        };
+    }
+
+    primitive_float_impl!(OrderedFloat<f32>, "float");
+    primitive_float_impl!(OrderedFloat<f64>, "double");
+    primitive_float_impl!(NotNan<f32>, "float");
+    primitive_float_impl!(NotNan<f64>, "double");
+
+    #[test]
+    fn schema_generation_does_not_panic_for_common_floats() {
+        fn test_schema_properties<T: schemars::JsonSchema>(title: &str) {
+            let schema = schemars::generate::SchemaGenerator::default().into_root_schema_for::<T>();
+
+            assert_eq!(
+                schema
+                    .get("type")
+                    .expect("schema defines `type` key")
+                    .as_str()
+                    .expect("value for the `type` key is a string"),
+                "number"
+            );
+            assert_eq!(
+                schema
+                    .get("title")
+                    .expect("schema defines `title` key")
+                    .as_str()
+                    .expect("value for the `title` key is a string"),
+                title
+            );
+            assert_eq!(
+                schema
+                    .get("format")
+                    .expect("schema defines `format` key")
+                    .as_str()
+                    .expect("value for the `format` key is a string"),
+                title
+            );
+        }
+
+        test_schema_properties::<OrderedFloat<f32>>("float");
+        test_schema_properties::<NotNan<f32>>("float");
+        test_schema_properties::<OrderedFloat<f64>>("double");
+        test_schema_properties::<NotNan<f64>>("double");
+    }
+
+    #[test]
+    fn ordered_float_schema_match_primitive_schema() {
+        fn test_schema_eq<Wrapped: schemars::JsonSchema, Inner: schemars::JsonSchema>() {
+            let wrapped_schema =
+                schemars::generate::SchemaGenerator::default().into_root_schema_for::<Wrapped>();
+            let primitive_schema =
+                schemars::generate::SchemaGenerator::default().into_root_schema_for::<Inner>();
+            assert_eq!(wrapped_schema, primitive_schema);
+        }
+
+        test_schema_eq::<OrderedFloat<f32>, f32>();
+        test_schema_eq::<NotNan<f32>, f32>();
+        test_schema_eq::<OrderedFloat<f64>, f64>();
+        test_schema_eq::<NotNan<f64>, f64>();
+    }
+}
+
 #[cfg(feature = "rand")]
 mod impl_rand {
     use super::{NotNan, OrderedFloat};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2651,9 +2651,9 @@ mod impl_schemars {
 
     #[test]
     fn schema_generation_does_not_panic_for_common_floats() {
-        {
-            let schema = schemars::gen::SchemaGenerator::default()
-                .into_root_schema_for::<OrderedFloat<f32>>();
+        fn test_schema_properties<T: schemars::JsonSchema>(title: &str) {
+            let schema = schemars::r#gen::SchemaGenerator::default().into_root_schema_for::<T>();
+
             assert_eq!(
                 schema.schema.instance_type,
                 Some(schemars::schema::SingleOrVec::Single(std::boxed::Box::new(
@@ -2662,82 +2662,31 @@ mod impl_schemars {
             );
             assert_eq!(
                 schema.schema.metadata.unwrap().title.unwrap(),
-                std::string::String::from("float")
+                std::string::String::from(title)
             );
         }
-        {
-            let schema = schemars::gen::SchemaGenerator::default()
-                .into_root_schema_for::<OrderedFloat<f64>>();
-            assert_eq!(
-                schema.schema.instance_type,
-                Some(schemars::schema::SingleOrVec::Single(std::boxed::Box::new(
-                    schemars::schema::InstanceType::Number
-                )))
-            );
-            assert_eq!(
-                schema.schema.metadata.unwrap().title.unwrap(),
-                std::string::String::from("double")
-            );
-        }
-        {
-            let schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<NotNan<f32>>();
-            assert_eq!(
-                schema.schema.instance_type,
-                Some(schemars::schema::SingleOrVec::Single(std::boxed::Box::new(
-                    schemars::schema::InstanceType::Number
-                )))
-            );
-            assert_eq!(
-                schema.schema.metadata.unwrap().title.unwrap(),
-                std::string::String::from("float")
-            );
-        }
-        {
-            let schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<NotNan<f64>>();
-            assert_eq!(
-                schema.schema.instance_type,
-                Some(schemars::schema::SingleOrVec::Single(std::boxed::Box::new(
-                    schemars::schema::InstanceType::Number
-                )))
-            );
-            assert_eq!(
-                schema.schema.metadata.unwrap().title.unwrap(),
-                std::string::String::from("double")
-            );
-        }
+
+        test_schema_properties::<OrderedFloat<f32>>("float");
+        test_schema_properties::<OrderedFloat<f64>>("double");
+        test_schema_properties::<NotNan<f32>>("float");
+        test_schema_properties::<NotNan<f64>>("double");
     }
+
     #[test]
     fn ordered_float_schema_match_primitive_schema() {
-        {
-            let of_schema = schemars::gen::SchemaGenerator::default()
-                .into_root_schema_for::<OrderedFloat<f32>>();
-            let prim_schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<f32>();
-            assert_eq!(of_schema, prim_schema);
+        fn test_schema_eq<Wrapped: schemars::JsonSchema, Inner: schemars::JsonSchema>() {
+            let wrapped_schema =
+                schemars::r#gen::SchemaGenerator::default().into_root_schema_for::<Wrapped>();
+            let primitive_schema =
+                schemars::r#gen::SchemaGenerator::default().into_root_schema_for::<Inner>();
+
+            assert_eq!(wrapped_schema, primitive_schema);
         }
-        {
-            let of_schema = schemars::gen::SchemaGenerator::default()
-                .into_root_schema_for::<OrderedFloat<f64>>();
-            let prim_schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<f64>();
-            assert_eq!(of_schema, prim_schema);
-        }
-        {
-            let of_schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<NotNan<f32>>();
-            let prim_schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<f32>();
-            assert_eq!(of_schema, prim_schema);
-        }
-        {
-            let of_schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<NotNan<f64>>();
-            let prim_schema =
-                schemars::gen::SchemaGenerator::default().into_root_schema_for::<f64>();
-            assert_eq!(of_schema, prim_schema);
-        }
+
+        test_schema_eq::<OrderedFloat<f32>, f32>();
+        test_schema_eq::<OrderedFloat<f64>, f64>();
+        test_schema_eq::<NotNan<f32>, f32>();
+        test_schema_eq::<NotNan<f64>, f64>();
     }
 }
 


### PR DESCRIPTION
Bump version of [schemars](https://docs.rs/schemars/latest/schemars/) to recently released 1.0.

Changes incldue:
- Module paths updates.
- Schema definition has been rewritten using `json_schema` macro.
- `JsonSchema` trait definition was changed, most notably `is_referenceable` has been changed to `inline_schema`([see](https://github.com/GREsau/schemars/blob/master/CHANGELOG.md#changed-%EF%B8%8F-breaking-changes-%EF%B8%8F-2) and [see](https://github.com/GREsau/schemars/blob/master/CHANGELOG.md#changed-3))
- tests have been updated to account for new schemas now using `serde_json::Value` internally [see](https://github.com/GREsau/schemars/blob/master/CHANGELOG.md#changed-%EF%B8%8F-breaking-changes-%EF%B8%8F-2)

I'm no expert at the schemars internals so everyone please feel free to correct / improve upon the current implementation.