### PR TITLE
impl_proptest: use `core` instead of `std`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2921,7 +2921,7 @@ mod impl_proptest {
     use proptest::arbitrary::{Arbitrary, StrategyFor};
     use proptest::num::{f32, f64};
     use proptest::strategy::{FilterMap, Map, Strategy};
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     macro_rules! impl_arbitrary {
         ($($f:ident),+) => {


### PR DESCRIPTION
This small fix allows to use the `proptest` feature without `std` feature.