### PR TITLE
Add From<OrderedFloat<f32>> for OrderedFloat<f64>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,13 @@ impl_ordered_float_from! {f32, i16}
 impl_ordered_float_from! {f32, u8}
 impl_ordered_float_from! {f32, u16}
 
+impl From<OrderedFloat<f32>> for OrderedFloat<f64> {
+    #[inline]
+    fn from(v: OrderedFloat<f32>) -> OrderedFloat<f64> {
+        OrderedFloat(v.0 as f64)
+    }
+}
+
 impl<T: FloatCore> Deref for OrderedFloat<T> {
     type Target = T;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -351,6 +351,15 @@ fn not_nan64_bounded() {
 }
 
 #[test]
+fn widen_f32_to_f64() {
+    let of: OrderedFloat<f64> = OrderedFloat(1.5f32).into();
+    assert_eq!(of, OrderedFloat(1.5f64));
+
+    let nn: NotNan<f64> = not_nan(1.5f32).into();
+    assert_eq!(nn, not_nan(1.5f64));
+}
+
+#[test]
 fn not_nan64_from_primitive() {
     assert_eq!(NotNan::<f64>::from_i8(42i8), Some(not_nan(42.0)));
     assert_eq!(NotNan::<f64>::from_u8(42u8), Some(not_nan(42.0)));


### PR DESCRIPTION
Mirrors the existing widening conversion on NotNan so OrderedFloat has the same API surface. Also adds test coverage for both the new impl and the previously-untested NotNan widening.